### PR TITLE
Logan create edit event validation

### DIFF
--- a/src/app/components/CreateEvent.tsx
+++ b/src/app/components/CreateEvent.tsx
@@ -16,31 +16,21 @@ import {
     } from '@chakra-ui/react'
 import { Button } from '@styles/Button'
 
-interface Props {
-    create: boolean;
-  }  
 
-/* if create var is True, it will be a Create Event component, 
-    otherwise it will be Edit Event Component */
     
-const CreateEditEvent = ({create}: Props) => {
+const CreateEvent = () => {
   const { isOpen, onOpen, onClose } = useDisclosure()
   return (
     <>
-      {/* <Button onClick={onOpen}>
-        <>
-            {create ? "Create " : "Edit "} Event
-
-        </>     
-      </Button> */}
+      <Button onClick={onOpen}>
+            Create Event
+      </Button>
 
       <Modal isOpen={isOpen} onClose={onClose} size='xl'>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader bg='#a3caf0' fontWeight='bold' position='relative'>
-            <>
-                {create ? "Create " : "Edit "} Event
-            </>
+              Create Event
           </ModalHeader>
           <ModalCloseButton size='l'/>    
 
@@ -74,9 +64,7 @@ const CreateEditEvent = ({create}: Props) => {
               Close
             </Button>
             <Button>
-                <>
-                    {create ? "Create" : "Save"}
-                </>
+                Create
             </Button>
           </ModalFooter>
         </ModalContent>
@@ -85,4 +73,4 @@ const CreateEditEvent = ({create}: Props) => {
   )
 }
 
-export default CreateEditEvent
+export default CreateEvent

--- a/src/app/components/CreateEvent.tsx
+++ b/src/app/components/CreateEvent.tsx
@@ -1,73 +1,157 @@
 import {
-    Modal,
-    ModalOverlay,
-    ModalContent,
-    ModalHeader,
-    ModalFooter,
-    ModalBody,
-    ModalCloseButton,
-    useDisclosure,
-    Input,
-    Textarea,
-    Select,
-    Switch,
-    Stack,
-    FormLabel
-    } from '@chakra-ui/react'
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+  useDisclosure,
+  Input,
+  Textarea,
+  Select,
+  Switch,
+  Stack,
+  FormControl,
+  FormLabel,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
+  NumberIncrementStepper,
+  NumberDecrementStepper
+} from '@chakra-ui/react'
 import { Button } from '@styles/Button'
+import React, {useState} from 'react';
 
-
-    
 const CreateEvent = () => {
-  const { isOpen, onOpen, onClose } = useDisclosure()
+  const { isOpen, onOpen, onClose } = useDisclosure() // button open/close
+
+  const [name, setName] = useState('') 
+  const [loc, setLoc] = useState('')
+  const [date, setDate] = useState('')
+  const [start, setStart] = useState('')
+  const [end, setEnd] = useState('')
+  const [desc, setDesc] = useState('')
+  const [type, setType] = useState('')
+  const [grps, setGrps] = useState(0)
+
+  const handleNameChange = (e: any) => setName(e.target.value)
+  const handleLocationChange = (e: any) => setLoc(e.target.value)
+  const handleDateChange = (e: any) => setDate(e.target.value)
+  const handleStartChange = (e: any) => setStart(e.target.value)
+  const handleEndChange = (e: any) => setEnd(e.target.value)
+  const handleDescChange = (e: any) => setDesc(e.target.value)
+  const handleTypeChange = (e: any) => setType(e.target.value)
+  const handleGrpsChange = (e: any) => setGrps(e)
+
+  const [isSubmitted, setIsSubmitted] = useState(false)
+
+  function HandleClose() {
+    setName('')
+    setLoc('')
+    setDate('')
+    setStart('')
+    setEnd('')
+    setDesc('')
+    setType('')
+    setGrps(0)
+    setIsSubmitted(false)
+    onClose()
+  }
+
+  function HandleSubmit() {setIsSubmitted(true)}
+
   return (
     <>
       <Button onClick={onOpen}>
-            Create Event
+        Create Event
       </Button>
 
-      <Modal isOpen={isOpen} onClose={onClose} size='xl'>
+      <Modal isOpen={isOpen} onClose={HandleClose} size='xl'>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader bg='#a3caf0' fontWeight='bold' position='relative'>
-              Create Event
+            Create Event
           </ModalHeader>
           <ModalCloseButton size='l'/>    
 
           <ModalBody>
             <Stack spacing={3}>
-                <Input variant='flushed' placeholder='Event Name' fontWeight='bold'/>
-                <Input variant='flushed' placeholder='Event Location' fontWeight='bold'/>
-                <Stack spacing={0}>
-                    <FormLabel color='grey' fontWeight='bold'>Event Date</FormLabel>
-                    <Input placeholder="Select Date" size="md" type="date" color='grey'/>
-                </Stack>
-                <Stack spacing={0}>
-                    <FormLabel color='grey' fontWeight='bold'>Event Time</FormLabel>
-                    <Input placeholder="Select Time" size="md" type="time" color='grey'/>
-                </Stack>
-                <Stack spacing={0}>
-                    <FormLabel color='grey' fontWeight='bold'>Event Description</FormLabel>
-                    <Textarea placeholder='Event Description' />
-                </Stack>
-                <Stack spacing={0}>
-                    <FormLabel color='grey' fontWeight='bold'>Event Type</FormLabel>
-                    <Select placeholder='Select option' color='grey'>
-                        <option value='option1'>Watery Walk</option>
-                        <option value='option2'>Pond Clean Up</option>
-                        <option value='option3'>Habitat Monitoring</option>
-                    </Select>
-                </Stack>
-                <Switch fontWeight='bold' color='grey'>Wheelchair Accessibility</Switch>
-                <Switch fontWeight='bold' color='grey'>Spanish Speaking Accommodation</Switch>
+
+              <FormControl isInvalid={name === '' && isSubmitted}>               
+                <Input variant='flushed' placeholder='Event Name' fontWeight='bold' value={name} onChange={handleNameChange}/>
+              </FormControl>
+
+              <FormControl isInvalid={loc === '' && isSubmitted}>               
+                <Input variant='flushed' placeholder='Event Location' fontWeight='bold' value={loc} onChange={handleLocationChange}/>
+              </FormControl>
+
+              <Stack spacing={0}>
+                <FormControl isInvalid={date === '' && isSubmitted}>
+                  <FormLabel color='grey' fontWeight='bold'>Event Date</FormLabel>
+                  <Input placeholder="Select Date" size="md" type="date" color='grey' value={date} onChange={handleDateChange}/>
+                </FormControl>
+              </Stack>
+
+              <Stack spacing={0}>
+                <FormControl isInvalid={start === '' && isSubmitted}>
+                  <FormLabel color='grey' fontWeight='bold'>Start Time</FormLabel>
+                  <Input placeholder="Select Time" size="md" type="time" color='grey' value={start} onChange={handleStartChange}/>
+                </FormControl>
+              </Stack>
+
+              <Stack spacing={0}>
+                <FormControl isInvalid={end === '' && isSubmitted}>
+                  <FormLabel color='grey' fontWeight='bold'>End Time</FormLabel>
+                  <Input placeholder="Select Time" size="md" type="time" color='grey' value={end} onChange={handleEndChange}/>
+                </FormControl>
+              </Stack>
+
+              <Stack spacing={0}>
+                <FormControl isInvalid={desc === '' && isSubmitted}>
+                  <FormLabel color='grey' fontWeight='bold'>Event Description</FormLabel>
+                  <Textarea placeholder='Event Description' value={desc} onChange={handleDescChange}/>
+                </FormControl>
+              </Stack>
+
+              <Stack spacing={0}>
+                <FormControl isInvalid={type === '' && isSubmitted}>
+                  <FormLabel color='grey' fontWeight='bold'>Event Type</FormLabel>
+                  <Select placeholder='Select option' color='grey' value={type} onChange={handleTypeChange}>
+                      <option value='option1'>Watery Walk</option>
+                      <option value='option2'>Pond Clean Up</option>
+                      <option value='option3'>Habitat Monitoring</option>
+                  </Select>
+                </FormControl>
+              </Stack>
+
+              <Stack spacing={0}>
+                <FormControl isInvalid={grps === 0 && isSubmitted}>
+                  <FormLabel color='grey' fontWeight='bold'>Number of Groups Allowed</FormLabel>
+                  <NumberInput allowMouseWheel step={5} value={grps} onChange={handleGrpsChange}>
+                    <NumberInputField />
+                    <NumberInputStepper>
+                      <NumberIncrementStepper />
+                      <NumberDecrementStepper />
+                    </NumberInputStepper>
+                  </NumberInput>
+                </FormControl>
+              </Stack>
+
+              <Switch fontWeight='bold' color='grey'>Volunteer Event</Switch>
+
+              <Switch fontWeight='bold' color='grey'>Wheelchair Accessibility</Switch>
+
+              <Switch fontWeight='bold' color='grey'>Spanish Speaking Accommodations</Switch>
+
             </Stack>
           </ModalBody>
 
           <ModalFooter>
-            <Button onClick={onClose}>
+            <Button onClick={HandleClose}>
               Close
             </Button>
-            <Button>
+            <Button onClick={HandleSubmit}>
                 Create
             </Button>
           </ModalFooter>

--- a/src/app/components/CreateEvent.tsx
+++ b/src/app/components/CreateEvent.tsx
@@ -43,6 +43,10 @@ const CreateEvent = () => {
                     <Input placeholder="Select Date" size="md" type="date" color='grey'/>
                 </Stack>
                 <Stack spacing={0}>
+                    <FormLabel color='grey' fontWeight='bold'>Event Time</FormLabel>
+                    <Input placeholder="Select Time" size="md" type="time" color='grey'/>
+                </Stack>
+                <Stack spacing={0}>
                     <FormLabel color='grey' fontWeight='bold'>Event Description</FormLabel>
                     <Textarea placeholder='Event Description' />
                 </Stack>

--- a/src/app/components/CreateEvent.tsx
+++ b/src/app/components/CreateEvent.tsx
@@ -13,12 +13,7 @@ import {
   Switch,
   Stack,
   FormControl,
-  FormLabel,
-  NumberInput,
-  NumberInputField,
-  NumberInputStepper,
-  NumberIncrementStepper,
-  NumberDecrementStepper
+  FormLabel
 } from '@chakra-ui/react'
 import { Button } from '@styles/Button'
 import React, {useState} from 'react';
@@ -33,7 +28,10 @@ const CreateEvent = () => {
   const [end, setEnd] = useState('')
   const [desc, setDesc] = useState('')
   const [type, setType] = useState('')
-  const [grps, setGrps] = useState(0)
+  const [vol, setVol] = useState(false)
+  const [myGrp, setMyGrp] = useState(false)
+  const [wc, setWC] = useState(false)
+  const [span, setSpan] = useState(false)
 
   const handleNameChange = (e: any) => setName(e.target.value)
   const handleLocationChange = (e: any) => setLoc(e.target.value)
@@ -42,7 +40,15 @@ const CreateEvent = () => {
   const handleEndChange = (e: any) => setEnd(e.target.value)
   const handleDescChange = (e: any) => setDesc(e.target.value)
   const handleTypeChange = (e: any) => setType(e.target.value)
-  const handleGrpsChange = (e: any) => setGrps(e)
+  const handleVolChange = () => {
+    setVol(!vol)
+    if(vol) {
+        setMyGrp(false)
+    }
+}
+  const handleMyGrp = () => setMyGrp(!myGrp)
+  const handleWCChange = () => setWC(!wc)
+  const handleSpanChange = () => setSpan(!span)
 
   const [isSubmitted, setIsSubmitted] = useState(false)
 
@@ -54,7 +60,10 @@ const CreateEvent = () => {
     setEnd('')
     setDesc('')
     setType('')
-    setGrps(0)
+    setVol(false)
+    setMyGrp(false)
+    setWC(false)
+    setSpan(false)    
     setIsSubmitted(false)
     onClose()
   }
@@ -125,24 +134,13 @@ const CreateEvent = () => {
                 </FormControl>
               </Stack>
 
-              <Stack spacing={0}>
-                <FormControl isInvalid={grps === 0 && isSubmitted}>
-                  <FormLabel color='grey' fontWeight='bold'>Number of Groups Allowed</FormLabel>
-                  <NumberInput allowMouseWheel step={5} value={grps} onChange={handleGrpsChange}>
-                    <NumberInputField />
-                    <NumberInputStepper>
-                      <NumberIncrementStepper />
-                      <NumberDecrementStepper />
-                    </NumberInputStepper>
-                  </NumberInput>
-                </FormControl>
-              </Stack>
+              <Switch fontWeight='bold' color='grey' isChecked={vol} onChange={handleVolChange}>Volunteer Event</Switch>
 
-              <Switch fontWeight='bold' color='grey'>Volunteer Event</Switch>
-
-              <Switch fontWeight='bold' color='grey'>Wheelchair Accessibility</Switch>
-
-              <Switch fontWeight='bold' color='grey'>Spanish Speaking Accommodations</Switch>
+              <Switch fontWeight='bold' color='grey' isDisabled={!vol} isFocusable={!vol} isChecked={myGrp} onChange={handleMyGrp}>Only My Group Allowed</Switch>
+  
+              <Switch fontWeight='bold' color='grey' isChecked={wc} onChange={handleWCChange}>Wheelchair Accessibility</Switch>
+  
+              <Switch fontWeight='bold' color='grey' isChecked={span} onChange={handleSpanChange}>Spanish Speaking Accommodations</Switch>
 
             </Stack>
           </ModalBody>

--- a/src/app/components/EditEvent.tsx
+++ b/src/app/components/EditEvent.tsx
@@ -42,6 +42,10 @@ const CreateEvent = () => {
                     <Input placeholder="Select Date" size="md" type="date" color='grey'/>
                 </Stack>
                 <Stack spacing={0}>
+                    <FormLabel color='grey' fontWeight='bold'>Event Time</FormLabel>
+                    <Input placeholder="Select Time" size="md" type="time" color='grey'/>
+                </Stack>
+                <Stack spacing={0}>
                     <FormLabel color='grey' fontWeight='bold'>Event Description</FormLabel>
                     <Textarea placeholder='Event Description' />
                 </Stack>

--- a/src/app/components/EditEvent.tsx
+++ b/src/app/components/EditEvent.tsx
@@ -1,0 +1,75 @@
+import {
+    Modal,
+    ModalOverlay,
+    ModalContent,
+    ModalHeader,
+    ModalFooter,
+    ModalBody,
+    ModalCloseButton,
+    useDisclosure,
+    Input,
+    Textarea,
+    Select,
+    Switch,
+    Stack,
+    FormLabel
+    } from '@chakra-ui/react'
+import { Button } from '@styles/Button'
+
+    
+const CreateEvent = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  return (
+    <>
+      <Button onClick={onOpen}>
+            Edit Event
+      </Button>
+
+      <Modal isOpen={isOpen} onClose={onClose} size='xl'>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader bg='#a3caf0' fontWeight='bold' position='relative'>
+            Edit Event
+          </ModalHeader>
+          <ModalCloseButton size='l'/>    
+
+          <ModalBody>
+            <Stack spacing={3}>
+                <Input variant='flushed' placeholder='Event Name' fontWeight='bold'/>
+                <Input variant='flushed' placeholder='Event Location' fontWeight='bold'/>
+                <Stack spacing={0}>
+                    <FormLabel color='grey' fontWeight='bold'>Event Date</FormLabel>
+                    <Input placeholder="Select Date" size="md" type="date" color='grey'/>
+                </Stack>
+                <Stack spacing={0}>
+                    <FormLabel color='grey' fontWeight='bold'>Event Description</FormLabel>
+                    <Textarea placeholder='Event Description' />
+                </Stack>
+                <Stack spacing={0}>
+                    <FormLabel color='grey' fontWeight='bold'>Event Type</FormLabel>
+                    <Select placeholder='Select option' color='grey'>
+                        <option value='option1'>Watery Walk</option>
+                        <option value='option2'>Pond Clean Up</option>
+                        <option value='option3'>Habitat Monitoring</option>
+                    </Select>
+                </Stack>
+                <Switch fontWeight='bold' color='grey'>Wheelchair Accessibility</Switch>
+                <Switch fontWeight='bold' color='grey'>Spanish Speaking Accommodation</Switch>
+            </Stack>
+          </ModalBody>
+
+          <ModalFooter>
+            <Button onClick={onClose}>
+              Close
+            </Button>
+            <Button>
+               Save
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>      
+  )
+}
+
+export default CreateEvent

--- a/src/app/components/EditEvent.tsx
+++ b/src/app/components/EditEvent.tsx
@@ -12,68 +12,157 @@ import {
     Select,
     Switch,
     Stack,
+    FormControl,
     FormLabel
-    } from '@chakra-ui/react'
-import { Button } from '@styles/Button'
+  } from '@chakra-ui/react'
+  import { IEvent } from '@database/eventSchema';
+  import { Button } from '@styles/Button'
+  import React, {useState} from 'react';  
+  
+  const EditEvent = (event: IEvent) => {
+    const { isOpen, onOpen, onClose } = useDisclosure() // button open/close
+  
+    const [name, setName] = useState(event.eventName) 
+    const [loc, setLoc] = useState(event.location)
+    const [date, setDate] = useState(getDate(event.startTime))
+    const [start, setStart] = useState(getTime(event.startTime))
+    const [end, setEnd] = useState(getTime(event.endTime))
+    const [desc, setDesc] = useState(event.description)
+    const [type, setType] = useState('')
+    const [vol, setVol] = useState(event.volunteerEvent)
+    const [myGrp, setMyGrp] = useState(false)
+    const [wc, setWC] = useState(event.wheelchairAccessible)
+    const [span, setSpan] = useState(event.spanishSpeakingAccommodation)
 
+  
+    const handleNameChange = (e: any) => setName(e.target.value)
+    const handleLocationChange = (e: any) => setLoc(e.target.value)
+    const handleDateChange = (e: any) => setDate(e.target.value)
+    const handleStartChange = (e: any) => setStart(e.target.value)
+    const handleEndChange = (e: any) => setEnd(e.target.value)
+    const handleDescChange = (e: any) => setDesc(e.target.value)
+    const handleTypeChange = (e: any) => setType(e.target.value)
+    const handleVolChange = () => {
+        setVol(!vol)
+        if(vol) {
+            setMyGrp(false)
+        }
+    }
+    const handleMyGrp = () => setMyGrp(!myGrp)
+    const handleWCChange = () => setWC(!wc)
+    const handleSpanChange = () => setSpan(!span)
     
-const CreateEvent = () => {
-  const { isOpen, onOpen, onClose } = useDisclosure()
-  return (
-    <>
-      <Button onClick={onOpen}>
-            Edit Event
-      </Button>
+    const [isSubmitted, setIsSubmitted] = useState(false)
+  
+    function HandleClose() {
+      setName(event.eventName)
+      setLoc(event.location)
+      setDate(getDate(event.startTime))
+      setStart(getTime(event.startTime))
+      setEnd(getTime(event.endTime))
+      setDesc(event.description)
+      setType('')
+      setVol(event.volunteerEvent)
+      setMyGrp(false)
+      setWC(event.wheelchairAccessible)
+      setSpan(event.spanishSpeakingAccommodation)
+      setIsSubmitted(false)
+      onClose()
+    }
 
-      <Modal isOpen={isOpen} onClose={onClose} size='xl'>
-        <ModalOverlay />
-        <ModalContent>
-          <ModalHeader bg='#a3caf0' fontWeight='bold' position='relative'>
-            Edit Event
-          </ModalHeader>
-          <ModalCloseButton size='l'/>    
-
-          <ModalBody>
-            <Stack spacing={3}>
-                <Input variant='flushed' placeholder='Event Name' fontWeight='bold'/>
-                <Input variant='flushed' placeholder='Event Location' fontWeight='bold'/>
+    function getDate(x:Date): string {return x.toISOString().substring(0, 10)}
+    function getTime(x:Date): string {return x.toISOString().substring(11, 16)}
+  
+    function HandleSubmit() {setIsSubmitted(true)}
+  
+    return (
+      <>
+        <Button onClick={onOpen}>
+          Edit Event
+        </Button>
+  
+        <Modal isOpen={isOpen} onClose={HandleClose} size='xl'>
+          <ModalOverlay />
+          <ModalContent>
+            <ModalHeader bg='#a3caf0' fontWeight='bold' position='relative'>
+              Edit Event
+            </ModalHeader>
+            <ModalCloseButton size='l'/>    
+  
+            <ModalBody>
+              <Stack spacing={3}>
+  
+                <FormControl isInvalid={name === '' && isSubmitted}>               
+                  <Input variant='flushed' placeholder='Event Name' fontWeight='bold' value={name} onChange={handleNameChange}/>
+                </FormControl>
+  
+                <FormControl isInvalid={loc === '' && isSubmitted}>               
+                  <Input variant='flushed' placeholder='Event Location' fontWeight='bold' value={loc} onChange={handleLocationChange}/>
+                </FormControl>
+  
                 <Stack spacing={0}>
+                  <FormControl isInvalid={date === '' && isSubmitted}>
                     <FormLabel color='grey' fontWeight='bold'>Event Date</FormLabel>
-                    <Input placeholder="Select Date" size="md" type="date" color='grey'/>
+                    <Input placeholder="Select Date" size="md" type="date" color='grey' value={date} onChange={handleDateChange}/>
+                  </FormControl>
                 </Stack>
+  
                 <Stack spacing={0}>
-                    <FormLabel color='grey' fontWeight='bold'>Event Time</FormLabel>
-                    <Input placeholder="Select Time" size="md" type="time" color='grey'/>
+                  <FormControl isInvalid={start === '' && isSubmitted}>
+                    <FormLabel color='grey' fontWeight='bold'>Start Time</FormLabel>
+                    <Input placeholder="Select Time" size="md" type="time" color='grey' value={start} onChange={handleStartChange}/>
+                  </FormControl>
                 </Stack>
+  
                 <Stack spacing={0}>
+                  <FormControl isInvalid={end === '' && isSubmitted}>
+                    <FormLabel color='grey' fontWeight='bold'>End Time</FormLabel>
+                    <Input placeholder="Select Time" size="md" type="time" color='grey' value={end} onChange={handleEndChange}/>
+                  </FormControl>
+                </Stack>
+  
+                <Stack spacing={0}>
+                  <FormControl isInvalid={desc === '' && isSubmitted}>
                     <FormLabel color='grey' fontWeight='bold'>Event Description</FormLabel>
-                    <Textarea placeholder='Event Description' />
+                    <Textarea placeholder='Event Description' value={desc} onChange={handleDescChange}/>
+                  </FormControl>
                 </Stack>
+  
                 <Stack spacing={0}>
+                  <FormControl isInvalid={type === '' && isSubmitted}>
                     <FormLabel color='grey' fontWeight='bold'>Event Type</FormLabel>
-                    <Select placeholder='Select option' color='grey'>
+                    <Select placeholder='Select option' color='grey' value={type} onChange={handleTypeChange}>
                         <option value='option1'>Watery Walk</option>
                         <option value='option2'>Pond Clean Up</option>
                         <option value='option3'>Habitat Monitoring</option>
                     </Select>
+                  </FormControl>
                 </Stack>
-                <Switch fontWeight='bold' color='grey'>Wheelchair Accessibility</Switch>
-                <Switch fontWeight='bold' color='grey'>Spanish Speaking Accommodation</Switch>
-            </Stack>
-          </ModalBody>
+  
+                <Switch fontWeight='bold' color='grey' isChecked={vol} onChange={handleVolChange}>Volunteer Event</Switch>
 
-          <ModalFooter>
-            <Button onClick={onClose}>
-              Close
-            </Button>
-            <Button>
-               Save
-            </Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
-    </>      
-  )
-}
-
-export default CreateEvent
+                <Switch fontWeight='bold' color='grey' isDisabled={!vol} isFocusable={!vol} isChecked={myGrp} onChange={handleMyGrp}>Only My Group Allowed</Switch>
+  
+                <Switch fontWeight='bold' color='grey' isChecked={wc} onChange={handleWCChange}>Wheelchair Accessibility</Switch>
+  
+                <Switch fontWeight='bold' color='grey' isChecked={span} onChange={handleSpanChange}>Spanish Speaking Accommodations</Switch>
+  
+              </Stack>
+            </ModalBody>
+  
+            <ModalFooter>
+              <Button onClick={HandleClose}>
+                Close
+              </Button>
+              <Button onClick={HandleSubmit}>
+                  Confirm
+              </Button>
+            </ModalFooter>
+          </ModalContent>
+        </Modal>
+      </>      
+    )
+  }
+  
+  export default EditEvent
+  

--- a/src/app/components/EditEvent.tsx
+++ b/src/app/components/EditEvent.tsx
@@ -70,8 +70,35 @@ import {
       onClose()
     }
 
-    function getDate(x:Date): string {return x.toISOString().substring(0, 10)}
-    function getTime(x:Date): string {return x.toISOString().substring(11, 16)}
+    function getDate(x:Date): string {
+        let localeDate: string = x.toLocaleDateString('en-Us')
+        let localeDateParts = localeDate.split('/')
+        let y: string = localeDateParts[2]
+        let m: string = localeDateParts[0]
+        let d: string = localeDateParts[1]
+        if (m.length == 1) {m = '0'.concat(m)}
+        if (d.length == 1) {d = '0'.concat(d)}
+        return y.concat('-', m, '-', d)
+    }
+
+    function getTime(x:Date): string {
+        let time: string = x.toLocaleTimeString()
+        let timeParts: string[] = time.split(':')
+        let h: string = timeParts[0]
+        let m: string = timeParts[1]
+        let amPM: string = timeParts[2].split(' ')[1]
+
+        if (h.localeCompare('12') == 0 && amPM.localeCompare('AM') == 0) {
+            h = (parseInt(h) - 12).toString() 
+        }
+        if (amPM.localeCompare('PM') == 0 && h.localeCompare('12') != 0) {
+            h = (parseInt(h) + 12).toString()
+        }
+        if (h.length == 1) {
+            h = '0'.concat(h)
+        }
+        return h.concat(':', m)
+    }
   
     function HandleSubmit() {setIsSubmitted(true)}
   


### PR DESCRIPTION
## Developer: Logan Costello

Closes #{ISSUE NUMBER HERE}

### Pull Request Summary

Refactored CreateEditEvent into CreateEvent and Edit Event.
EditEvent takes event as input.
EditEvent fills in the fields from the event when opened.
Added start and end time to both components
Added volunteer event switch to both components
Added Only my group allowed switch to both components (only available when volunteer event is true. volunteer event being false makes this switch false and disabled.
Implemented validation for all fields (switches are inherently selected already, so they don't require it)

Note: the components have an event type, but the event schema does not. One of these will likely need to change in the future to accommodate each other. If this is an unintended issue, I can fix it.

### Modifications

Created CreateEvent and EditEvent
Deleted CreateEditEvent

### Testing Considerations

Tested manually all possibilities I could think of

### Pull Request Checklist

- [X] Code is neat, readable, and works
- [X] Comments are appropriate
- [X] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [X] The developer name is specified
- [X] The summary is completed
- [X] Assign reviewers

### Screenshots/Screencast

https://github.com/hack4impact-calpoly/slo-beaver-brigade/assets/122325479/605bf7a6-6896-4101-a65d-b5ac54930c1b


