### PR TITLE
Standardized 'group'/'invitee' as 'group' across site

### DIFF
--- a/src/app/admin/events/create/page.tsx
+++ b/src/app/admin/events/create/page.tsx
@@ -71,7 +71,7 @@ export default function Page() {
   const [eventEnd, setEventEnd] = useState("");
   const [activeDate, setActiveDate] = useState("");
   const [eventTypes, setEventTypes] = useState<string[]>([]);
-  const [onlyInvitees, setOnlyInvitees] = useState<boolean>(false)
+  const [onlyGroups, setOnlyGroups] = useState<boolean>(false)
   const [sendEmailInvitees, setSendEmailInvitees] = useState<boolean>(false)
 
 
@@ -240,7 +240,7 @@ export default function Page() {
       endTime: eventEnd,
       volunteerEvent: eventType === "Volunteer",
       groupsAllowed: groupsSelected.map(group => group._id as string),
-      groupsOnly: onlyInvitees
+      groupsOnly: onlyGroups
     };
 
     // Attempt to create event via API and handle response
@@ -575,7 +575,7 @@ export default function Page() {
 
             <FormControl>
             <FormLabel htmlFor="invitees" fontWeight="bold">
-              Invitees Only
+              Only Available to Selected Groups
             </FormLabel>
             <Select
               id="invitees"
@@ -586,7 +586,7 @@ export default function Page() {
               ]}
               defaultInputValue="No"
               onChange={(option) =>
-                setOnlyInvitees(option ? option.value == "Yes" : false)
+                setOnlyGroups(option ? option.value == "Yes" : false)
               }
               chakraStyles={{
                 control: (provided) => ({
@@ -596,9 +596,9 @@ export default function Page() {
               }}
             />
           </FormControl>
-          {onlyInvitees && groups && <div className="flex sm:flex-row flex-col-reverse gap-5 sm:gap-10 sm:items-center ">
+          {onlyGroups && groups && <div className="flex sm:flex-row flex-col-reverse gap-5 sm:gap-10 sm:items-center ">
           <CreateTemporaryGroup groups={groupsSelected} mutate={mutateGroups} setGroups={setGroupsSelected}/>
-          <div className="flex flex-row gap-4 justify-center"> Notify Invitees: <Checkbox checked={sendEmailInvitees} onChange={() => setSendEmailInvitees((checked) => !checked)}></Checkbox></div>
+          <div className="flex flex-row gap-4 justify-center"> Notify Group Individuals: <Checkbox checked={sendEmailInvitees} onChange={() => setSendEmailInvitees((checked) => !checked)}></Checkbox></div>
             </div>}
 
           <FormControl isRequired>

--- a/src/app/components/EditEvent.tsx
+++ b/src/app/components/EditEvent.tsx
@@ -345,7 +345,7 @@ const EditEvent = ({event, initialGroups, mutate}: {event: IEvent, initialGroups
                 isChecked={myGrp}
                 onChange={handleMyGrp}
               >
-                Groups Only
+                Only Available to Selected Groups
               </Switch>
 
               <Switch


### PR DESCRIPTION
## Developer: Vinpatrik Magdangal

Closes #202 

### Pull Request Summary

Combined all uses of "Group", "Group Only", "Invitee Only" into just "Group". "Group Only" and "Invitee Only" turned into "Only Available to Selected Groups". Related variable "inviteeOnly" renamed to "groupOnly" as well.

### Modifications

- **modified**:   src/app/admin/events/create/**page.tsx**
- **modified**:   src/app/components/**EditEvent.tsx**

### Testing Considerations

No tests, just renamed invitee ->  group & "Group Only" to "Only Available to Selected Groups"

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

![image](https://github.com/user-attachments/assets/115ab667-d9d7-4d8b-91ae-1625e8569c7f)
![image](https://github.com/user-attachments/assets/41e9cace-0f19-4417-a6d2-47145fb39e19)

