### PR TITLE
Log Delte PR

### DIFF
--- a/src/app/api/user/[userId]/route.ts
+++ b/src/app/api/user/[userId]/route.ts
@@ -114,9 +114,7 @@ export async function DELETE(req: NextRequest, {params}: IParams) {
     const bodyText = await new Response(req.body).text();
     const email = JSON.parse(bodyText);
 
-
     try {
-
 
         const clerkUser = await clerkClient.users.getUserList({emailAddress: [email]});
         await clerkClient.users.deleteUser(clerkUser.data[0].id);

--- a/src/app/api/user/[userId]/route.ts
+++ b/src/app/api/user/[userId]/route.ts
@@ -4,7 +4,9 @@ import Group from "@database/groupSchema";
 import Event from "@database/eventSchema";
 import { NextResponse, NextRequest } from "next/server";
 import { revalidateTag } from "next/cache";
-import { clerkClient } from '@clerk/nextjs/server'
+import { clerkClient } from '@clerk/nextjs/server';
+import Log from "@database/logSchema";
+
 
 
 type IParams = {
@@ -143,6 +145,14 @@ export async function DELETE(req: NextRequest, {params}: IParams) {
         await Event.updateMany({registeredIds: userId},
             {$pull: {registeredIds: userId}, $push: {registeredIds: null}}
         )
+
+        // Log deletion to admin log
+        await Log.create({
+            user: `${user.firstName} ${user.lastName}`,
+            action: "deleted account",
+            date: new Date(),
+            link: null
+          });
 
         return NextResponse.json("User deleted: " + userId, { status: 200 });
 

--- a/src/app/api/user/[userId]/route.ts
+++ b/src/app/api/user/[userId]/route.ts
@@ -129,7 +129,6 @@ export async function DELETE(req: NextRequest, {params}: IParams) {
             );
         }
 
-
         // Remove user from groups
         await Group.updateMany({groupees: userId}, 
             {$pull: {groupees: userId}});

--- a/src/app/api/user/[userId]/route.ts
+++ b/src/app/api/user/[userId]/route.ts
@@ -138,13 +138,30 @@ export async function DELETE(req: NextRequest, {params}: IParams) {
         
 
         // Update events - set attendee ID to be null
-        await Event.updateMany({attendeeIds: userId},
-            {$pull: {attendeeIds: userId}, $push: {attendeeIds: null}}
-        )
+        await Event.updateMany(
+            {attendeeIds: userId},  // Find documents where userId exists in attendeeIds
+            { 
+                $set: { 
+                    attendeeIds: 
+                        // Directly replace all elements with `null`
+                        await Event.aggregate([{ $match: { attendeeIds: userId }}])
+                }
+            }
+        );
 
-        await Event.updateMany({registeredIds: userId},
-            {$pull: {registeredIds: userId}, $push: {registeredIds: null}}
-        )
+        // Update events - set attendee ID to be null
+        await Event.updateMany(
+            {registeredIds: userId},  // Find documents where userId exists in attendeeIds
+            { 
+                $set: { 
+                    attendeeIds: 
+                        // Directly replace all elements with `null`
+                        await Event.aggregate([{ $match: { registeredIds: userId }}])
+                }
+            }
+        );
+
+        
 
         // Log deletion to admin log
         await Log.create({

--- a/src/database/logSchema.ts
+++ b/src/database/logSchema.ts
@@ -23,7 +23,7 @@ const logSchema = new Schema({
     },
     link: {
         type: Schema.Types.ObjectId,
-        required: true,
+        required: false,
     },
 });
 


### PR DESCRIPTION
## Developer: Brady Welsh

Closes #210 

### Pull Request Summary

With these changes, upon an account's deletion, a log object is created and pushed to the DB. In addition, fixed an error caused by updating the Events table for account deletion.

### Modifications

- database/logSchema.ts: Slightly adjusted the schema to change link required to false, as we do not want a reference to an ObjectId that no longer exists
- api/user/[UserId]/route.ts: Creates the log object and sends it to the database. Additionally, updated code to correctly edit Events table on user deletion without any issues

### Testing Considerations

- I've tested that the correct object is sent to the logs table
- The only other thing to consider is if an admin deletes an account, should the admin's id/name/info be linked to the deletion in the log? I considered this but chose not to implement this because it would require making a fairly big change to the log schema, but it's something to think about for the future.

### Screenshots/Screencast

<img width="726" alt="image" src="https://github.com/user-attachments/assets/ea372ae0-aaa8-4cfe-b044-b4f48a212318" />
