### PR TITLE
Event template backend routes

### DIFF
--- a/src/app/api/eventtemplate/[eventTemplateId]/route.ts
+++ b/src/app/api/eventtemplate/[eventTemplateId]/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from "next/server";
+import connectDB from "@database/db";
+import Event, { IEvent } from "@database/eventTemplateSchema";
+import { revalidateTag } from "next/cache";
+
+type IParams = {
+    params: {
+        eventTemplateId: string;
+    };
+};
+
+export async function GET(req: NextRequest, {params} : IParams) {
+    await connectDB();
+    const { eventTemplateId } = params;
+
+    try {
+        const eventTemplate = await Event.findById(eventTemplateId).orFail();
+        return NextResponse.json(eventTemplate);
+    } catch (err: any) {
+        return NextResponse.json(
+            "Event Template not found with EventTemplateId = " + eventTemplateId + " " + err, 
+            {status: 404}
+        )
+    }
+
+}
+
+export async function DELETE(req: NextRequest, {params}: IParams) {
+    await connectDB();
+    const { eventTemplateId } = params;
+
+    try {
+        const eventTemplate = await Event.findByIdAndDelete(eventTemplateId).orFail();
+        revalidateTag("eventTemplates");
+
+        // For now, I didn't make it so other tables would be affected by this. 
+        // Not sure if this will be the case later, but the Event Template schema hasn't been merged with main at time of 
+        // working on this.
+
+        return NextResponse.json("Event template deleted: " + eventTemplateId, {
+            status: 200,
+        });
+
+    } catch (err: any) {
+        return NextResponse.json(
+            "Event not deleted (EventTemplateId = " + eventTemplateId + ") " + err,
+            { status: 400 }
+        );
+
+    }
+}
+
+export async function PUT(req: NextRequest, {params}: IParams) {
+    await connectDB();
+    const {eventTemplateId} = params;
+
+    try {
+        const eventTemplate = await Event.findById(eventTemplateId).orFail();
+
+        // TODO: COMPARE VALUES OF BODY WITH EVENT TEMPLATE OBJECT (WILL NEED SCHEMA COMPLETED)
+
+        if (req.body) {
+            const {
+                eventName,
+                location,
+                eventType,
+                description,
+                startTime,
+                endTime,
+                wheelchairAccessible,
+                spanishSpeakingAccommodation,
+                volunteerEvent,
+                groupsAllowed,
+                attendeeIds,
+                groupsOnly,
+            }: IEvent = await req.json();
+            if (location) {
+                eventTemplate.location = location;
+            }
+            if (eventName) {
+                eventTemplate.eventName = eventName;
+            }
+            if (description) {
+                eventTemplate.description = description;
+            }
+            if (startTime) {
+                eventTemplate.startTime = startTime;
+            }
+            if (endTime) {
+                eventTemplate.endTime = endTime;
+            }
+            if (wheelchairAccessible) {
+                eventTemplate.wheelchairAccessible = wheelchairAccessible;
+            }
+            if (spanishSpeakingAccommodation) {
+                eventTemplate.spanishSpeakingAccommodation =
+                    spanishSpeakingAccommodation;
+            }
+            if (volunteerEvent) {
+                eventTemplate.volunteerEvent = volunteerEvent;
+            }
+            if (groupsAllowed) {
+                eventTemplate.groupsAllowed = groupsAllowed;
+            }
+            if (eventType) {
+                eventTemplate.eventType = eventType;
+            }
+            if (attendeeIds){
+                eventTemplate.attendeeIds = attendeeIds;
+            }
+            eventTemplate.groupsOnly = groupsOnly;
+        }
+
+        await eventTemplate.save();
+        revalidateTag("eventTemplates");
+        return NextResponse.json("Event template updated: " + eventTemplate, { status: 200 });
+
+    } catch (err: any) {
+        return NextResponse.json(
+            "Event template not updated (EventId = " + eventTemplateId + ") " + err,
+            { status: 400 }
+        );
+
+    }
+}

--- a/src/app/api/eventtemplate/route.ts
+++ b/src/app/api/eventtemplate/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import connectDB from "@database/db";
+import Event, { IEvent } from "@database/eventTemplateSchema";
+import { revalidateTag } from "next/cache";
+
+
+
+
+// FOR CREATING AN EVENT TEMPLATE
+
+export async function POST(req: NextRequest) {
+    await connectDB();
+    const eventTemplate: IEvent = await req.json();
+
+    try {
+        const newEventTemplate = new Event(eventTemplate);
+
+
+        const createdEventTemplate = await newEventTemplate.save();
+        revalidateTag("eventTemplates");
+
+
+
+    } catch (err: any) {
+        if (err.name === "ValidationError") {
+            // Handle validation errors
+            const errors = Object.values(err.errors).map(
+                (error: any) => error.message
+            );
+            return NextResponse.json("Validation error: " + errors.join(", "), {
+                status: 400,
+            });
+        } else {
+            return NextResponse.json("Event Template not added: " + err, {
+                status: 400,
+            });
+        }
+
+    }
+
+}

--- a/src/app/api/eventtemplate/route.ts
+++ b/src/app/api/eventtemplate/route.ts
@@ -19,6 +19,10 @@ export async function POST(req: NextRequest) {
         const createdEventTemplate = await newEventTemplate.save();
         revalidateTag("eventTemplates");
 
+        return NextResponse.json(newEventTemplate, {
+            status: 200,
+        });
+
 
 
     } catch (err: any) {


### PR DESCRIPTION
## Developer: Brady Welsh

Closes #222

### Pull Request Summary

- Simple CRUD operations for Event Templates (GET, POST, DELETE, PUT), which are based on the Event routes and follow the new Event Template Schema

### Modifications

- created api/eventtemplate/route.ts - contains basic POST Route
- created api/eventtemplate/[EventTemplateId]/route.ts - contains GET, DELETE, and PUT Requests

### Testing Considerations

- In the screenshots, I put the tests I used (with Postman) - all of them were successful
- I'm not entirely sure how Event Templates are being implemented in the frontend, so it's possible that more routes may be needed in the future depending on their use

### Screenshots/Screencast

<img width="1443" alt="Image" src="https://github.com/user-attachments/assets/d568c770-464b-4511-8e6c-a83c7f3b23cd" />

<img width="1050" alt="Image" src="https://github.com/user-attachments/assets/114d631c-30fb-4412-a929-d67783b9ad13" />

<img width="1050" alt="Image" src="https://github.com/user-attachments/assets/93b3f0c1-fe0e-4f1e-a2da-5cdc94cbe6f0" />

<img width="1050" alt="Image" src="https://github.com/user-attachments/assets/bd53e6f1-2ea7-4335-83a8-2ad7b27498a9" />

<img width="1050" alt="Image" src="https://github.com/user-attachments/assets/f26d6b1f-3aa8-42cd-be35-85b1ce482cc5" />
