### PR TITLE
faet: audit logs perm changes + Patch API updated

### DIFF
--- a/src/app/actions/makeAdminUser.ts
+++ b/src/app/actions/makeAdminUser.ts
@@ -1,6 +1,7 @@
 "use server"
 import User from "@database/userSchema";
 import connectDB from "database/db";
+import Log from "@database/logSchema";
 
 const makeAdminUser = async (email: string) => {
   await connectDB();
@@ -14,6 +15,13 @@ const makeAdminUser = async (email: string) => {
     if (!user) {
       throw new Error(`User with email ${email} not found`);
     }
+
+    // add an audit log entry
+    await Log.create({
+      user: `${user.firstName} ${user.lastName}`,
+      action: `reverted ${user.firstName} ${user.lastName} to user`,
+      date: new Date(),
+    });
 
     return user.toObject();
   } catch (error) {

--- a/src/app/actions/makeUserAdmin.ts
+++ b/src/app/actions/makeUserAdmin.ts
@@ -1,6 +1,7 @@
 "use server"
 import User from "@database/userSchema";
 import connectDB from "database/db";
+import Log from "@database/logSchema";
 
 const makeUserAdmin = async (email: string) => {
   await connectDB();
@@ -14,6 +15,13 @@ const makeUserAdmin = async (email: string) => {
     if (!user) {
       throw new Error(`User with email ${email} not found`);
     }
+
+    // add an audit log entry
+    await Log.create({
+      user: `${user.firstName} ${user.lastName}`,
+      action: `changed ${user.firstName} ${user.lastName} to admin`,
+      date: new Date(),
+    });
 
     return user.toObject();
   } catch (error) {

--- a/src/app/actions/makeUserAdmin.ts
+++ b/src/app/actions/makeUserAdmin.ts
@@ -2,6 +2,7 @@
 import User from "@database/userSchema";
 import connectDB from "database/db";
 import Log from "@database/logSchema";
+import { currentUser } from "@clerk/nextjs/server";
 
 const makeUserAdmin = async (email: string) => {
   await connectDB();
@@ -16,9 +17,21 @@ const makeUserAdmin = async (email: string) => {
       throw new Error(`User with email ${email} not found`);
     }
 
+    // Get the currently logged-in user (the admin making the change)
+    const curUser = await currentUser();
+    if (!curUser) {
+      throw new Error("No admin user found");
+    }
+
+    // Find the admin user in the database
+    const adminUser = await User.findOne({ email: curUser.emailAddresses[0].emailAddress });
+    if (!adminUser) {
+      throw new Error(`Admin user with email ${curUser.emailAddresses[0].emailAddress } not found`);
+    }
+
     // add an audit log entry
     await Log.create({
-      user: `${user.firstName} ${user.lastName}`,
+      user: `${curUser.firstName} ${curUser.lastName}`,
       action: `changed ${user.firstName} ${user.lastName} to admin`,
       date: new Date(),
     });

--- a/src/app/api/user/[userId]/route.ts
+++ b/src/app/api/user/[userId]/route.ts
@@ -119,7 +119,14 @@ export async function PATCH(req: NextRequest, { params }: IParams) {
             await targetUser.save();
             
             // action for audit log
-            const action = `changed ${targetUser.firstName} ${targetUser.lastName}'s role to ${role}`;
+            let action;
+            if (role === "admin") {
+                action = `changed ${targetUser.firstName} ${targetUser.lastName}'s role to admin`;
+            } else if (role === "user") {
+                action = `reverted ${targetUser.firstName} ${targetUser.lastName}'s role to user`;
+            } else {
+                action = `changed ${targetUser.firstName} ${targetUser.lastName}'s role to ${role}`;
+            }
 
             await Log.create({
                 user: `${user.firstName} ${user.lastName}`,

--- a/src/app/api/user/[userId]/route.ts
+++ b/src/app/api/user/[userId]/route.ts
@@ -101,7 +101,7 @@ export async function PATCH(req: NextRequest, { params }: IParams) {
         const { eventsAttended, role, targetUserId}: { eventsAttended?: string[], role?: string, targetUserId?: string } = await req.json();
 
         // Handle permission updates (Only allow admins to change permissions)
-        const allowedRoles = ["user", "admin"]; // list of allowed roles (should this be defined somewhere else?)
+        const allowedRoles = ["user", "admin", "superAdmin"]; // list of allowed roles
         if (role && targetUserId) {
             if (!allowedRoles.includes(role)) {
                 return NextResponse.json({ error: `Invalid role: ${role}` }, { status: 400 });
@@ -117,6 +117,10 @@ export async function PATCH(req: NextRequest, { params }: IParams) {
                     { error: "Target user not found" },
                     { status: 404 }
                 );
+            }
+
+            if (targetUser.role === role) {
+                return NextResponse.json({ error: "User already has that role." }, { status: 400 });
             }
 
             // update role
@@ -219,7 +223,4 @@ export async function DELETE(req: NextRequest, {params}: IParams) {
             { status: 400 }
         );
     }
-
-
-
 }

--- a/src/app/api/user/[userId]/route.ts
+++ b/src/app/api/user/[userId]/route.ts
@@ -98,7 +98,6 @@ export async function PATCH(req: NextRequest, { params }: IParams) {
             );
         }
 
-        // const { role, eventsAttended }: { role?: string, eventsAttended?: string[] } = await req.json();
         const { eventsAttended, role, targetUserId}: { eventsAttended?: string[], role?: string, targetUserId?: string } = await req.json();
 
         // Handle permission updates (Only allow admins to change permissions)

--- a/src/app/api/user/[userId]/route.ts
+++ b/src/app/api/user/[userId]/route.ts
@@ -75,15 +75,6 @@ export async function POST(
     }
 }
 
-// create a new audit log upon changing a users permissions
-async function logPermissionChange(user: IUser, action: string) {
-    await Log.create({
-        user: `${user.firstName} ${user.lastName}`,
-        action: action,
-        date: new Date(),
-    });
-}
-
 export async function PATCH(req: NextRequest, { params }: IParams) {
     await connectDB(); // Connect to the database
 
@@ -130,7 +121,11 @@ export async function PATCH(req: NextRequest, { params }: IParams) {
             // action for audit log
             const action = `changed ${targetUser.firstName} ${targetUser.lastName}'s role to ${role}`;
 
-            await logPermissionChange(user, action);
+            await Log.create({
+                user: `${user.firstName} ${user.lastName}`,
+                action: action,
+                date: new Date(),
+            });
 
             return NextResponse.json("User updated: " + targetUserId, { status: 200 });
         }


### PR DESCRIPTION
## Developer: Emily Lai

Closes #212

### Pull Request Summary

- Updated PATCH api, makeAdminUser, and makeUserAdmin actions to allow an admin user to change another user's role via the change role button in the user list or using the backend API
example req body: 
`{
    "role": "user",
    "targetUserId": "67c6617d7e2fe35fcb763b5a"
}`
- The change is recorded on the audit log page

### Modifications

`slo-beaver-brigade\src\app\api\user\[userId]\route.ts` -> PATCH API updated
makeAdminUser and makeUserAdmin now create audit logs

### Testing Considerations

API
- errors when a normal user attempts to change a user's permission, error
- error when attempting to change a user's role to something that doesn't exist
- error when attempting to change a user's role to the same role
- changing a user to user/admin should be reflected in the database
Both API and frontend actions
- audit log updates accordingly

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshot
![image](https://github.com/user-attachments/assets/97aadeeb-5b3a-436c-93b7-63565ab55dac)

### Extra note
Super admin role may be introduced later on, which will affect this current pr

