### PR TITLE
Create event UI updates

### DIFF
--- a/src/app/admin/events/create/create.module.css
+++ b/src/app/admin/events/create/create.module.css
@@ -1,0 +1,50 @@
+.twoThirdsGrid {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.halfGrid {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.leftColumn {
+  display: flex;
+  flex-direction: column;
+  width: 57%;
+}
+
+.rightColumn {
+  display: flex;
+  flex-direction: column;
+  width: 37%;
+}
+
+.halfColumn {
+  display: flex;
+  flex-direction: column;
+  width: 47%;
+}
+
+.wrapper {
+  margin: 10px;
+ }
+.preview ul{
+  list-style-type: circle;
+  padding-left: 2rem;
+}
+
+.preview ol{
+  list-style-type: decimal;
+  padding-left: 2rem;
+}
+
+.signup_button{
+   padding-right: 50px;
+}
+
+.login_button{
+   padding-right: 50px;
+}

--- a/src/app/admin/events/create/create.module.css
+++ b/src/app/admin/events/create/create.module.css
@@ -48,3 +48,27 @@
 .login_button{
    padding-right: 50px;
 }
+
+@media (max-width: 640px) {
+  .twoThirdsGrid {
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .halfGrid {
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .leftColumn {
+    width: 100%;
+  }
+
+  .rightColumn {
+    width: 100%;
+  }
+
+  .halfColumn {
+    width: 100%;
+  }
+}

--- a/src/app/admin/events/create/create.module.css
+++ b/src/app/admin/events/create/create.module.css
@@ -13,7 +13,7 @@
 .leftColumn {
   display: flex;
   flex-direction: column;
-  width: 57%;
+  width: 60%;
 }
 
 .rightColumn {
@@ -22,10 +22,16 @@
   width: 37%;
 }
 
-.halfColumn {
+.halfLeftColumn {
   display: flex;
   flex-direction: column;
-  width: 47%;
+  width: 48%;
+}
+
+.halfRightColumn {
+  display: flex;
+  flex-direction: column;
+  width: 49%;
 }
 
 .wrapper {
@@ -68,7 +74,11 @@
     width: 100%;
   }
 
-  .halfColumn {
+  .halfLeftColumn {
+    width: 100%;
+  }
+
+  .halfRightColumn {
     width: 100%;
   }
 }

--- a/src/app/admin/events/create/page.tsx
+++ b/src/app/admin/events/create/page.tsx
@@ -648,7 +648,7 @@ export default function Page() {
             </div>
 
             <div className={style.rightColumn}> 
-              <FormControl isRequired className={style.rightColumn}>
+              <FormControl>
                 <FormLabel htmlFor="volunteer-hours" fontWeight="bold">
                   Volunteer Hours
                 </FormLabel>
@@ -680,7 +680,7 @@ export default function Page() {
 
             {/* Row 2: Assign Groups and Only Available to Selected Groups */}
             <div>
-              <FormControl isRequired>
+              <FormControl>
               <FormLabel htmlFor="organization" fontWeight="bold">
                 Assign Groups
               </FormLabel>
@@ -722,7 +722,7 @@ export default function Page() {
 
           <div className={style.halfGrid}>
           <div className={style.halfLeftColumn}>
-              <FormControl isRequired>
+              <FormControl>
                 <FormLabel htmlFor="invitees" fontWeight="bold">
                   Groups Only
                 </FormLabel>
@@ -752,7 +752,7 @@ export default function Page() {
             </div>
 
             <div className={style.halfRightColumn}>
-              <FormControl isRequired>
+              <FormControl>
                 <FormLabel htmlFor="invitees" fontWeight="bold">
                   Notify Group Members
                 </FormLabel>

--- a/src/app/admin/events/create/page.tsx
+++ b/src/app/admin/events/create/page.tsx
@@ -897,23 +897,23 @@ export default function Page() {
 
       <Box display="flex" justifyContent="center" mt={4} gap={4}>
         <Button
+          bg="#48a0e0"
+          color="white"
+          _hover={{ bg: "#377ab8" }}
+          onClick={handleSaveAsTemplate}
+          minWidth="170px"
+        >
+          Save as Template
+        </Button>
+        <Button
           loadingText="Creating"
           bg="#e0af48"
           color="black"
           _hover={{ bg: "#C19137" }}
           onClick={handleCreateEvent}
-          minWidth="150px"
+          minWidth="170px"
         >
           Create Event
-        </Button>
-        <Button
-          bg="#48a0e0"
-          color="white"
-          _hover={{ bg: "#377ab8" }}
-          onClick={handleSaveAsTemplate}
-          minWidth="150px"
-        >
-          Save as Template
         </Button>
       </Box>
     </Box>

--- a/src/app/admin/events/create/page.tsx
+++ b/src/app/admin/events/create/page.tsx
@@ -590,8 +590,8 @@ export default function Page() {
         ></ImageSelector>
       </Flex>
 
-      <Flex direction={{ base: "column", xl: "row" }} gap={{base: 10, xl: 16}} mb={6} mt={6}>
-        <VStack spacing={4} align="stretch" flex="1" maxWidth={{ base: "100%", xl: "55%" }}>
+      <Flex direction={{ base: "column", xl: "row" }} gap={{base: 10, 'xl': 12}} mb={6} mt={6}>
+        <VStack spacing={4} align="stretch" flex="1" maxWidth={{ base: "100%", 'xl': "45%" }}>
           <FormControl isRequired>
             <FormLabel htmlFor="event-name" fontWeight="bold">
               Event Name
@@ -678,9 +678,8 @@ export default function Page() {
             </div>
           </div>
 
-          <div className={style.twoThirdsGrid}>
             {/* Row 2: Assign Groups and Only Available to Selected Groups */}
-            <div className={style.leftColumn}>
+            <div>
               <FormControl isRequired>
               <FormLabel htmlFor="organization" fontWeight="bold">
                 Assign Groups
@@ -721,7 +720,8 @@ export default function Page() {
               </FormControl>
             </div>
 
-            <div className={style.rightColumn}>
+          <div className={style.halfGrid}>
+          <div className={style.halfColumn}>
               <FormControl isRequired>
                 <FormLabel htmlFor="invitees" fontWeight="bold">
                   Groups Only?
@@ -740,6 +740,36 @@ export default function Page() {
                   }
                   onChange={(option) =>
                     setOnlyGroups(option ? option.value === "Yes" : false)
+                  }
+                  chakraStyles={{
+                    control: (provided) => ({
+                      ...provided,
+                      textAlign: "left",
+                    }),
+                  }}
+                />
+              </FormControl>
+            </div>
+
+            <div className={style.halfColumn}>
+              <FormControl isRequired>
+                <FormLabel htmlFor="invitees" fontWeight="bold">
+                  Notify Group Members?
+                </FormLabel>
+                <Select
+                  id="invitees"
+                  placeholder="Select an Option"
+                  options={[
+                    { value: "Yes", label: "Yes" },
+                    { value: "No", label: "No" },
+                  ]}
+                  value={
+                    sendEmailInvitees
+                      ? { value: "Yes", label: "Yes" }
+                      : { value: "No", label: "No" }
+                  }
+                  onChange={(option) =>
+                    setSendEmailInvitees(option ? option.value === "Yes" : false)
                   }
                   chakraStyles={{
                     control: (provided) => ({
@@ -787,7 +817,7 @@ export default function Page() {
             <div className={style.halfColumn}>
               <FormControl isRequired>
               <FormLabel htmlFor="accessibility" fontWeight="bold">
-                Accessibile Access
+                Wheelchair Accessibile
               </FormLabel>
               <Select
                 id="accessibility"

--- a/src/app/admin/events/create/page.tsx
+++ b/src/app/admin/events/create/page.tsx
@@ -512,7 +512,7 @@ export default function Page() {
           Create New Event
         </Text>
         <Menu>
-          <MenuButton as={Button} rightIcon={<ChevronDownIcon />}>
+          <MenuButton as={Button} rightIcon={<ChevronDownIcon />} minWidth={'180px'} >
             {selectedTemplate ? selectedTemplate.eventName : "Select Template"}
           </MenuButton>
           <MenuList>

--- a/src/app/admin/events/create/page.tsx
+++ b/src/app/admin/events/create/page.tsx
@@ -650,7 +650,7 @@ export default function Page() {
             <div className={style.rightColumn}> 
               <FormControl isRequired className={style.rightColumn}>
                 <FormLabel htmlFor="volunteer-hours" fontWeight="bold">
-                  Volunteer Hours?
+                  Volunteer Hours
                 </FormLabel>
                 <Select
                   id="volunteer-hours"

--- a/src/app/admin/events/create/page.tsx
+++ b/src/app/admin/events/create/page.tsx
@@ -29,7 +29,6 @@ import { useRouter } from "next/navigation";
 import { uploadFileS3Bucket } from "app/lib/clientActions";
 import { Select, CreatableSelect } from "chakra-react-select";
 import MDEditor from "@uiw/react-md-editor";
-import style from "@styles/calendar/calendar.module.css";
 import ImageSelector from "app/components/ImageSelector";
 import { useEventsAscending, useGroups } from "app/lib/swrfunctions";
 import { CreateTemporaryGroup } from "app/components/ViewGroups";
@@ -37,6 +36,7 @@ import { IGroup } from "database/groupSchema";
 import { IEvent } from "database/eventSchema";
 import { IEventTemplate } from "database/eventTemplateSchema";
 // import { IEvent } from "database/eventTemplateSchema";
+import style from "./create.module.css";
 import "../../../fonts/fonts.css";
 import { set } from "mongoose";
 
@@ -497,30 +497,42 @@ export default function Page() {
   }, []);
 
   return (
-    <Box p={[0, 8, 8, 8]} mx="10">
-      <Flex justifyContent="space-between" alignItems="center" mb={4}>
-    <Text fontSize="2xl" fontWeight="bold" color="black" mt={-12} mb={3}>
-      Create New Event
-    </Text>
-    <Menu>
-      <MenuButton as={Button} rightIcon={<ChevronDownIcon />}>
-        {selectedTemplate ? selectedTemplate.eventName : "Select Template"}
-      </MenuButton>
-      <MenuList>
-        {templates.map((template) => (
-          <MenuItem key={template._id} onClick={() => handleSelectTemplate(template)}>
-            {template.eventName}
-          </MenuItem>
-        ))}
-      </MenuList>
-    </Menu>
-  </Flex>
+    <Box px="1%" pb="8" mx="4%">
+      <Box
+        justifyContent="space-between"
+        alignItems="center"
+        display="flex"
+        flexDirection="row"
+      >
+        <Text
+          fontSize="2xl"
+          fontWeight="bold"
+          color="black"
+        >
+          Create New Event
+        </Text>
+        <Menu>
+          <MenuButton as={Button} rightIcon={<ChevronDownIcon />}>
+            {selectedTemplate ? selectedTemplate.eventName : "Select Template"}
+          </MenuButton>
+          <MenuList>
+            {templates.map((template) => (
+              <MenuItem
+                key={template._id}
+                onClick={() => handleSelectTemplate(template)}
+              >
+                {template.eventName}
+              </MenuItem>
+            ))}
+          </MenuList>
+        </Menu>
+      </Box>
 
       {/* image uploading */}
       <Flex
         flexDir={{ base: "column", md: "row" }}
         flex="1"
-        gap={{ base: "10px", md: "50px" }}
+        gap={{ base: "10px", md: "10px" }}
       >
         <FormControl mb="4" onClick={promptFileInput} cursor="pointer">
           <Input
@@ -578,8 +590,8 @@ export default function Page() {
         ></ImageSelector>
       </Flex>
 
-      <Flex direction={{ base: "column", md: "row" }} gap={20} mb={6} mt={6}>
-        <VStack spacing={4} align="stretch" flex="1">
+      <Flex direction={{ base: "column", xl: "row" }} gap={{base: 10, xl: 16}} mb={6} mt={6}>
+        <VStack spacing={4} align="stretch" flex="1" maxWidth={{ base: "100%", xl: "55%" }}>
           <FormControl isRequired>
             <FormLabel htmlFor="event-name" fontWeight="bold">
               Event Name
@@ -604,66 +616,72 @@ export default function Page() {
             />
           </FormControl>
 
-          <SimpleGrid
-            columns={{ base: 1, lg: 2 }}
-            spacing={6}
-            w="100%"
-          >
+          <div className={style.twoThirdsGrid}>
             {/* Row 1: Event Type and Volunteer Hours */}
-            <FormControl isRequired>
-              <FormLabel htmlFor="event-type" fontWeight="bold">
-                Event Type
-              </FormLabel>
-              <CreatableSelect
-                id="event-type"
-                placeholder="Select or create event type"
-                options={eventTypes.map((type) => ({
-                  value: type,
-                  label: type,
-                }))}
-                value={eventType ? { value: eventType, label: eventType } : null}
-                onChange={(option) => setEventType(option ? option.value : "")}
-                chakraStyles={{
-                  control: (provided) => ({
-                    ...provided,
-                    textAlign: "left",
-                  }),
-                }}
-                isClearable
-                isSearchable
-              />
-            </FormControl>
+            <div className={style.leftColumn}>
+              <FormControl isRequired>
+                  <FormLabel
+                  htmlFor="event-type"
+                  fontWeight="bold"
+                  >
+                  Event Type
+                  </FormLabel>
+                <CreatableSelect
+                  id="event-type"
+                  placeholder="Select or create event type"
+                  options={eventTypes.map((type) => ({
+                    value: type,
+                    label: type,
+                  }))}
+                  value={eventType ? { value: eventType, label: eventType } : null}
+                  onChange={(option) => setEventType(option ? option.value : "")}
+                  chakraStyles={{
+                    control: (provided) => ({
+                      ...provided,
+                      textAlign: "left",
+                    }),
+                  }}
+                  isClearable
+                  isSearchable
+                />
+              </FormControl>
+            </div>
 
-            <FormControl isRequired>
-              <FormLabel htmlFor="volunteer-hours" fontWeight="bold">
-                Counts for Volunteer Hours
-              </FormLabel>
-              <Select
-                id="volunteer-hours"
-                placeholder="Select an Option"
-                options={[
-                  { value: "Yes", label: "Yes" },
-                  { value: "No", label: "No" },
-                ]}
-                value={
-                  isVolunteerEvent
-                    ? { value: "Yes", label: "Yes" }
-                    : { value: "No", label: "No" }
-                }
-                onChange={(option) =>
-                  setIsVolunteerEvent(option ? option.value === "Yes" : false)
-                }
-                chakraStyles={{
-                  control: (provided) => ({
-                    ...provided,
-                    textAlign: "left",
-                  }),
-                }}
-              />
-            </FormControl>
+            <div className={style.rightColumn}> 
+              <FormControl isRequired className={style.rightColumn}>
+                <FormLabel htmlFor="volunteer-hours" fontWeight="bold">
+                  Volunteer Hours?
+                </FormLabel>
+                <Select
+                  id="volunteer-hours"
+                  placeholder="Select an Option"
+                  options={[
+                    { value: "Yes", label: "Yes" },
+                    { value: "No", label: "No" },
+                  ]}
+                  value={
+                    isVolunteerEvent
+                      ? { value: "Yes", label: "Yes" }
+                      : { value: "No", label: "No" }
+                  }
+                  onChange={(option) =>
+                    setIsVolunteerEvent(option ? option.value === "Yes" : false)
+                  }
+                  chakraStyles={{
+                    control: (provided) => ({
+                      ...provided,
+                      textAlign: "left",
+                    }),
+                  }}
+                />
+              </FormControl>
+            </div>
+          </div>
 
+          <div className={style.twoThirdsGrid}>
             {/* Row 2: Assign Groups and Only Available to Selected Groups */}
-            <FormControl isRequired>
+            <div className={style.leftColumn}>
+              <FormControl isRequired>
               <FormLabel htmlFor="organization" fontWeight="bold">
                 Assign Groups
               </FormLabel>
@@ -671,155 +689,136 @@ export default function Page() {
                 id="organization"
                 placeholder="Select or create organization"
                 options={groups?.map((group) => ({
-                  value: group._id,
-                  label: group.group_name,
+                value: group._id,
+                label: group.group_name,
                 }))}
                 value={groupsSelected.map((group) => ({
-                  value: group._id,
-                  label: group.group_name,
+                value: group._id,
+                label: group.group_name,
                 }))}
                 onChange={(selectedOptions) =>
-                  setGroupsSelected(
-                    selectedOptions
-                      ? selectedOptions.map((option) => ({
-                          _id: option.value,
-                          group_name: option.label,
-                          groupees: [],
-                        }))
-                      : []
-                  )
+                setGroupsSelected(
+                  selectedOptions
+                  ? selectedOptions.map((option) => ({
+                    _id: option.value,
+                    group_name: option.label,
+                    groupees: [],
+                    }))
+                  : []
+                )
                 }
                 onCreateOption={handleCreateNewGroup}
                 chakraStyles={{
-                  control: (provided) => ({
-                    ...provided,
-                    textAlign: "left",
-                  }),
+                control: (provided) => ({
+                  ...provided,
+                  textAlign: "left",
+                }),
                 }}
                 isMulti
                 isClearable
                 isSearchable
               />
-            </FormControl>
+              </FormControl>
+            </div>
 
-            <FormControl isRequired>
-              <FormLabel htmlFor="invitees" fontWeight="bold">
-                Only Available to Selected Groups
-              </FormLabel>
-              <Select
-                id="invitees"
-                placeholder="Select an Option"
-                options={[
-                  { value: "Yes", label: "Yes" },
-                  { value: "No", label: "No" },
-                ]}
-                value={
-                  onlyGroups
-                    ? { value: "Yes", label: "Yes" }
-                    : { value: "No", label: "No" }
-                }
-                onChange={(option) =>
-                  setOnlyGroups(option ? option.value === "Yes" : false)
-                }
-                chakraStyles={{
-                  control: (provided) => ({
-                    ...provided,
-                    textAlign: "left",
-                  }),
-                }}
-              />
-            </FormControl>
-
+            <div className={style.rightColumn}>
+              <FormControl isRequired>
+                <FormLabel htmlFor="invitees" fontWeight="bold">
+                  Groups Only?
+                </FormLabel>
+                <Select
+                  id="invitees"
+                  placeholder="Select an Option"
+                  options={[
+                    { value: "Yes", label: "Yes" },
+                    { value: "No", label: "No" },
+                  ]}
+                  value={
+                    onlyGroups
+                      ? { value: "Yes", label: "Yes" }
+                      : { value: "No", label: "No" }
+                  }
+                  onChange={(option) =>
+                    setOnlyGroups(option ? option.value === "Yes" : false)
+                  }
+                  chakraStyles={{
+                    control: (provided) => ({
+                      ...provided,
+                      textAlign: "left",
+                    }),
+                  }}
+                />
+              </FormControl>
+            </div>
+          </div>
+            
+          <div className={style.halfGrid}>
             {/* Row 3: Accommodations */}
-            <FormControl isRequired>
+            <div className={style.halfColumn}>
+              <FormControl isRequired>
               <FormLabel htmlFor="spanishAccommodation" fontWeight="bold">
-                Spanish Speaking Accommodation
+                Spanish Speaking
               </FormLabel>
               <Select
                 id="accommodation-type"
                 placeholder="Select an Option"
                 options={[
-                  { value: "Yes", label: "Yes" },
-                  { value: "No", label: "No" },
+                { value: "Yes", label: "Yes" },
+                { value: "No", label: "No" },
                 ]}
                 value={
-                  spanishSpeaking !== ""
-                    ? { value: spanishSpeaking, label: spanishSpeaking }
-                    : null
+                spanishSpeaking !== ""
+                  ? { value: spanishSpeaking, label: spanishSpeaking }
+                  : null
                 }
                 onChange={(option) =>
-                  setSpanishSpeaking(option ? option.value : "")
+                setSpanishSpeaking(option ? option.value : "")
                 }
                 chakraStyles={{
-                  control: (provided) => ({
-                    ...provided,
-                    textAlign: "left",
-                  }),
+                control: (provided) => ({
+                  ...provided,
+                  textAlign: "left",
+                }),
                 }}
               />
-            </FormControl>
+              </FormControl>
+            </div>
 
-            <FormControl isRequired>
+            <div className={style.halfColumn}>
+              <FormControl isRequired>
               <FormLabel htmlFor="accessibility" fontWeight="bold">
-                Accessibility Accommodation
+                Accessibile Access
               </FormLabel>
               <Select
                 id="accessibility"
                 placeholder="Select an Option"
                 options={[
-                  { value: "Yes", label: "Yes" },
-                  { value: "No", label: "No" },
-                ]}
-                value={
-                  accessibilityAccommodation !== ""
-                    ? { value: accessibilityAccommodation, label: accessibilityAccommodation }
-                    : null
-                }
-                onChange={(option) =>
-                  setAccessibilityAccommodation(option ? option.value : "")
-                }
-                chakraStyles={{
-                  control: (provided) => ({
-                    ...provided,
-                    textAlign: "left",
-                  }),
-                }}
-              />
-            </FormControl>
-          </SimpleGrid>
-
-          <FormControl isRequired>
-            <FormLabel htmlFor="accessibility" fontWeight="bold">
-              Accessibility Accommodation
-            </FormLabel>
-            <Select
-              id="accessibility"
-              placeholder="Select an Option"
-              options={[
                 { value: "Yes", label: "Yes" },
                 { value: "No", label: "No" },
-              ]}
-              value={
-                accessibilityAccommodation != ""
+                ]}
+                value={
+                accessibilityAccommodation !== ""
                   ? { value: accessibilityAccommodation, label: accessibilityAccommodation }
                   : null
-              }
-              onChange={(option) =>
+                }
+                onChange={(option) =>
                 setAccessibilityAccommodation(option ? option.value : "")
-              }
-              chakraStyles={{
+                }
+                chakraStyles={{
                 control: (provided) => ({
                   ...provided,
                   textAlign: "left",
                 }),
-              }}
-            />
-          </FormControl>
+                }}
+              />
+              </FormControl>
+            </div>
+          </div>
         </VStack>
         
-        <Flex flex="1">
+        <Flex alignItems="center" justifyContent="center">
           <VStack alignItems="flex-start">
-            <Text fontWeight="bold"  mt={{ base: "-16", md: "0" }} mb="-4">
+            <Text fontWeight="bold" >
               Date/Time
             </Text>
             {/* MiniCalendar */}

--- a/src/app/admin/events/create/page.tsx
+++ b/src/app/admin/events/create/page.tsx
@@ -19,6 +19,7 @@ import {
   Flex,
   Stack,
   Textarea,
+  SimpleGrid,
   IconButton,
 } from "@chakra-ui/react";
 import { AddIcon, ChevronDownIcon } from "@chakra-ui/icons";
@@ -92,6 +93,7 @@ export default function Page() {
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [eventType, setEventType] = useState("");
   const [eventTypes, setEventTypes] = useState<string[]>([]);
+  const [isVolunteerEvent, setIsVolunteerEvent] = useState(false);
   const [organizationIds, setOrganizationIds] = useState<string[]>([]);
   const [groupsSelected, setGroupsSelected] = useState<IGroup[]>([]);
   const { groups, isLoading, isError, mutateGroups } = useGroups();
@@ -590,8 +592,25 @@ export default function Page() {
             />
           </FormControl>
 
-          <HStack justifyContent="space-between">
-            <FormControl width="48%">
+          <FormControl isRequired>
+            <FormLabel htmlFor="location" fontWeight="bold">
+              Location
+            </FormLabel>
+            <Input
+              id="location"
+              placeholder="Enter event location"
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+            />
+          </FormControl>
+
+          <SimpleGrid
+            columns={{ base: 1, lg: 2 }}
+            spacing={6}
+            w="100%"
+          >
+            {/* Row 1: Event Type and Volunteer Hours */}
+            <FormControl isRequired>
               <FormLabel htmlFor="event-type" fontWeight="bold">
                 Event Type
               </FormLabel>
@@ -615,7 +634,36 @@ export default function Page() {
               />
             </FormControl>
 
-            <FormControl width="48%">
+            <FormControl isRequired>
+              <FormLabel htmlFor="volunteer-hours" fontWeight="bold">
+                Counts for Volunteer Hours
+              </FormLabel>
+              <Select
+                id="volunteer-hours"
+                placeholder="Select an Option"
+                options={[
+                  { value: "Yes", label: "Yes" },
+                  { value: "No", label: "No" },
+                ]}
+                value={
+                  isVolunteerEvent
+                    ? { value: "Yes", label: "Yes" }
+                    : { value: "No", label: "No" }
+                }
+                onChange={(option) =>
+                  setIsVolunteerEvent(option ? option.value === "Yes" : false)
+                }
+                chakraStyles={{
+                  control: (provided) => ({
+                    ...provided,
+                    textAlign: "left",
+                  }),
+                }}
+              />
+            </FormControl>
+
+            {/* Row 2: Assign Groups and Only Available to Selected Groups */}
+            <FormControl isRequired>
               <FormLabel htmlFor="organization" fontWeight="bold">
                 Assign Groups
               </FormLabel>
@@ -633,7 +681,11 @@ export default function Page() {
                 onChange={(selectedOptions) =>
                   setGroupsSelected(
                     selectedOptions
-                      ? selectedOptions.map((option) => ({ _id: option.value, group_name: option.label, groupees: [] }))
+                      ? selectedOptions.map((option) => ({
+                          _id: option.value,
+                          group_name: option.label,
+                          groupees: [],
+                        }))
                       : []
                   )
                 }
@@ -649,48 +701,94 @@ export default function Page() {
                 isSearchable
               />
             </FormControl>
-          </HStack>
+
+            <FormControl isRequired>
+              <FormLabel htmlFor="invitees" fontWeight="bold">
+                Only Available to Selected Groups
+              </FormLabel>
+              <Select
+                id="invitees"
+                placeholder="Select an Option"
+                options={[
+                  { value: "Yes", label: "Yes" },
+                  { value: "No", label: "No" },
+                ]}
+                value={
+                  onlyGroups
+                    ? { value: "Yes", label: "Yes" }
+                    : { value: "No", label: "No" }
+                }
+                onChange={(option) =>
+                  setOnlyGroups(option ? option.value === "Yes" : false)
+                }
+                chakraStyles={{
+                  control: (provided) => ({
+                    ...provided,
+                    textAlign: "left",
+                  }),
+                }}
+              />
+            </FormControl>
+
+            {/* Row 3: Accommodations */}
+            <FormControl isRequired>
+              <FormLabel htmlFor="spanishAccommodation" fontWeight="bold">
+                Spanish Speaking Accommodation
+              </FormLabel>
+              <Select
+                id="accommodation-type"
+                placeholder="Select an Option"
+                options={[
+                  { value: "Yes", label: "Yes" },
+                  { value: "No", label: "No" },
+                ]}
+                value={
+                  spanishSpeaking !== ""
+                    ? { value: spanishSpeaking, label: spanishSpeaking }
+                    : null
+                }
+                onChange={(option) =>
+                  setSpanishSpeaking(option ? option.value : "")
+                }
+                chakraStyles={{
+                  control: (provided) => ({
+                    ...provided,
+                    textAlign: "left",
+                  }),
+                }}
+              />
+            </FormControl>
+
+            <FormControl isRequired>
+              <FormLabel htmlFor="accessibility" fontWeight="bold">
+                Accessibility Accommodation
+              </FormLabel>
+              <Select
+                id="accessibility"
+                placeholder="Select an Option"
+                options={[
+                  { value: "Yes", label: "Yes" },
+                  { value: "No", label: "No" },
+                ]}
+                value={
+                  accessibilityAccommodation !== ""
+                    ? { value: accessibilityAccommodation, label: accessibilityAccommodation }
+                    : null
+                }
+                onChange={(option) =>
+                  setAccessibilityAccommodation(option ? option.value : "")
+                }
+                chakraStyles={{
+                  control: (provided) => ({
+                    ...provided,
+                    textAlign: "left",
+                  }),
+                }}
+              />
+            </FormControl>
+          </SimpleGrid>
 
           <FormControl isRequired>
-            <FormLabel htmlFor="location" fontWeight="bold">
-              Location
-            </FormLabel>
-            <Input
-              id="location"
-              placeholder="Enter event location"
-              value={location}
-              onChange={(e) => setLocation(e.target.value)}
-            />
-          </FormControl>
-
-          <FormControl>
-            <FormLabel htmlFor="spanishAccommodation" fontWeight="bold">
-              Spanish Speaking Accommodation
-            </FormLabel>
-            <Select
-              id="accommodation-type"
-              // value={}
-              placeholder="Select an Option"
-              options={[
-                { value: "Yes", label: "Yes" },
-                { value: "No", label: "No" },
-              ]}
-              value={
-                spanishSpeaking != ""
-                  ? { value: spanishSpeaking, label: spanishSpeaking }
-                  : null
-              }
-              onChange={(option) => setSpanishSpeaking(option ? option.value : "")}
-              chakraStyles={{
-                control: (provided) => ({
-                  ...provided,
-                  textAlign: "left",
-                }),
-              }}
-            ></Select>
-          </FormControl>
-
-          <FormControl>
             <FormLabel htmlFor="accessibility" fontWeight="bold">
               Accessibility Accommodation
             </FormLabel>
@@ -717,51 +815,8 @@ export default function Page() {
               }}
             />
           </FormControl>
-
-          <FormControl>
-            <FormLabel htmlFor="invitees" fontWeight="bold">
-              Only Available to Selected Groups
-            </FormLabel>
-            <Select
-              id="invitees"
-              placeholder="Select an Option"
-              options={[
-                { value: "Yes", label: "Yes" },
-                { value: "No", label: "No" },
-              ]}
-              value={
-                onlyGroups
-                  ? { value: "Yes", label: "Yes" }
-                  : { value: "No", label: "No" }}
-              onChange={(option) =>
-                setOnlyGroups(option ? option.value == "Yes" : false)
-              }
-              chakraStyles={{
-                control: (provided) => ({
-                  ...provided,
-                  textAlign: "left",
-                }),
-              }}
-            />
-          </FormControl>
-          {onlyGroups && groups && (
-            <div className="flex sm:flex-row flex-col-reverse gap-5 sm:gap-10 sm:items-center ">
-              <CreateTemporaryGroup
-                groups={groupsSelected}
-                mutate={mutateGroups}
-                setGroups={setGroupsSelected}
-              />
-              <div className="flex flex-row gap-4 justify-center">
-                {" "}
-                Notify Group Individuals:{" "}
-                <Checkbox
-                  checked={sendEmailInvitees}
-                  onChange={() => setSendEmailInvitees((checked) => !checked)}
-                ></Checkbox>
-              </div>
-            </div>
-          )}
         </VStack>
+        
         <Flex flex="1">
           <VStack alignItems="flex-start">
             <Text fontWeight="bold"  mt={{ base: "-16", md: "0" }} mb="-4">

--- a/src/app/admin/events/create/page.tsx
+++ b/src/app/admin/events/create/page.tsx
@@ -724,7 +724,7 @@ export default function Page() {
           <div className={style.halfColumn}>
               <FormControl isRequired>
                 <FormLabel htmlFor="invitees" fontWeight="bold">
-                  Groups Only?
+                  Groups Only
                 </FormLabel>
                 <Select
                   id="invitees"
@@ -754,7 +754,7 @@ export default function Page() {
             <div className={style.halfColumn}>
               <FormControl isRequired>
                 <FormLabel htmlFor="invitees" fontWeight="bold">
-                  Notify Group Members?
+                  Notify Group Members
                 </FormLabel>
                 <Select
                   id="invitees"

--- a/src/app/admin/events/create/page.tsx
+++ b/src/app/admin/events/create/page.tsx
@@ -721,7 +721,7 @@ export default function Page() {
             </div>
 
           <div className={style.halfGrid}>
-          <div className={style.halfColumn}>
+          <div className={style.halfLeftColumn}>
               <FormControl isRequired>
                 <FormLabel htmlFor="invitees" fontWeight="bold">
                   Groups Only
@@ -751,7 +751,7 @@ export default function Page() {
               </FormControl>
             </div>
 
-            <div className={style.halfColumn}>
+            <div className={style.halfRightColumn}>
               <FormControl isRequired>
                 <FormLabel htmlFor="invitees" fontWeight="bold">
                   Notify Group Members
@@ -784,7 +784,7 @@ export default function Page() {
             
           <div className={style.halfGrid}>
             {/* Row 3: Accommodations */}
-            <div className={style.halfColumn}>
+            <div className={style.halfLeftColumn}>
               <FormControl isRequired>
               <FormLabel htmlFor="spanishAccommodation" fontWeight="bold">
                 Spanish Speaking
@@ -814,7 +814,7 @@ export default function Page() {
               </FormControl>
             </div>
 
-            <div className={style.halfColumn}>
+            <div className={style.halfRightColumn}>
               <FormControl isRequired>
               <FormLabel htmlFor="accessibility" fontWeight="bold">
                 Wheelchair Accessibile


### PR DESCRIPTION
## Developer: Jason Jelincic

Closes #201 

### Pull Request Summary

Updates to the create events page to improve the ui at smaller screens and make the page format consistent at all points. (no hidden fields)

### Modifications

admin/events/create/page.tsx
admin/events/create/crate.module.css

### Testing Considerations

created a event with the new ui

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast
old:
<img width="1696" alt="Screenshot 2025-03-30 at 12 32 59 AM" src="https://github.com/user-attachments/assets/4caed6ea-348a-44f0-94dd-0738091c061f" />
<img width="813" alt="Screenshot 2025-03-30 at 12 33 36 AM" src="https://github.com/user-attachments/assets/d361f077-4dab-46e0-8602-a3c8456818e3" />
<img width="579" alt="Screenshot 2025-03-30 at 12 34 22 AM" src="https://github.com/user-attachments/assets/16eef64a-cb27-4ffb-8314-28b449f834ff" />

New:
<img width="1634" alt="Screenshot 2025-03-30 at 12 34 52 AM" src="https://github.com/user-attachments/assets/d35f755c-4e00-4f34-b211-9e1c75c26324" />
<img width="893" alt="Screenshot 2025-03-30 at 12 35 19 AM" src="https://github.com/user-attachments/assets/9755485e-213c-4bb2-bc9c-8caf16469852" />
<img width="456" alt="Screenshot 2025-03-30 at 12 35 43 AM" src="https://github.com/user-attachments/assets/881b4c91-0ba2-4a9f-984a-a9fd003efa54" />




