### PR TITLE
Connect Backend and Frontend Event Template Code 

### DIFF
--- a/src/app/admin/events/create/page.tsx
+++ b/src/app/admin/events/create/page.tsx
@@ -54,6 +54,8 @@ export default function Page() {
   const router = useRouter();
   const [eventName, setEventName] = useState("");
   const [selectedTemplate, setSelectedTemplate] = useState<IEventTemplate | null>(null);
+  const [templates, setTemplates] = useState<IEventTemplate[]>([]);
+  /*
   const [templates, setTemplates] = useState<IEventTemplate[]>([
     {
       _id: "1",
@@ -90,6 +92,7 @@ export default function Page() {
       registeredIds: [],
     },
   ]);
+  */
   const [coverImage, setCoverImage] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [eventType, setEventType] = useState("");
@@ -136,6 +139,8 @@ export default function Page() {
       }
     });
   };
+
+
 
   const handleTimeChange = (start: string, end: string) => {
     // Format for parsing input times (handle both 12-hour and 24-hour formats)
@@ -470,9 +475,30 @@ export default function Page() {
       } catch (error) {
         console.error("Error fetching event types:", error);
       }
+
+    };
+
+    const fetchEventTemplates = async ()  => {
+
+      const response = await fetch("/api/eventtemplate/", {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+  
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+  
+      const templates = await response.json();
+  
+      setTemplates(templates);
+  
     };
 
     fetchEventTypes();
+    fetchEventTemplates();
   }, []);
 
   const mockEvent = {

--- a/src/app/admin/events/create/page.tsx
+++ b/src/app/admin/events/create/page.tsx
@@ -210,30 +210,59 @@ export default function Page() {
       registeredIds: [],
     };
 
-    const response = await fetch("/api/eventtemplate/", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(newTemplateData),
-    });
+    let response;
+    console.log("Selected Template ID:", selectedTemplate?._id);
+    console.log("Templates Array:", templates);
+    if (templates.some(template => template.eventName === eventName)) {
+      response = await fetch(`/api/eventtemplate/${selectedTemplate?._id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(newTemplateData),
+      });
 
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const updatedTemplate: IEventTemplate = await response.json();
+      setTemplates((prevTemplates) =>
+        prevTemplates.map((template) =>
+          template._id === updatedTemplate._id ? updatedTemplate : template
+        )
+      );
+      
+      toast({
+        title: "Template Updated",
+        description: "This event template has been updated.",
+        status: "success",
+        duration: 2500,
+        isClosable: true,
+      });
+    } else {
+      response = await fetch("/api/eventtemplate/", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(newTemplateData),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const newTemplate: IEventTemplate = await response.json();
+      setTemplates([...templates, newTemplate]);
+  
+      toast({
+        title: "Template Saved",
+        description: "This event has been saved as a template.",
+        status: "success",
+        duration: 2500,
+        isClosable: true,
+      });
     }
 
-    const newTemplate: IEventTemplate = await response.json();
-
-    setTemplates([...templates, newTemplate]);
-
-  
-    toast({
-      title: "Template Saved",
-      description: "This event has been saved as a template.",
-      status: "success",
-      duration: 2500,
-      isClosable: true,
-    });
   };  
 
   // Handle file selection for the event cover image and set preview
@@ -512,7 +541,7 @@ export default function Page() {
         </Text>
         <Menu>
           <MenuButton as={Button} rightIcon={<ChevronDownIcon />} minWidth={'180px'} >
-            {selectedTemplate ? selectedTemplate.eventName : "Select Template"}
+            Select Template
           </MenuButton>
           <MenuList>
             {templates.map((template) => (

--- a/src/app/admin/events/create/page.tsx
+++ b/src/app/admin/events/create/page.tsx
@@ -231,8 +231,7 @@ export default function Page() {
   };  
   
   const handleSaveAsTemplate = async () => {
-    const newTemplate: IEventTemplate = {
-      _id: (templates.length + 1).toString(),
+    const newTemplateData = {
       eventName,
       eventImage: imagePreview,
       eventType,
@@ -248,8 +247,23 @@ export default function Page() {
       groupsAllowed: groupsSelected.map(group => group._id),
       registeredIds: [],
     };
-  
+
+    const response = await fetch("/api/eventtemplate/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(newTemplateData),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const newTemplate: IEventTemplate = await response.json();
+
     setTemplates([...templates, newTemplate]);
+
   
     toast({
       title: "Template Saved",

--- a/src/app/admin/events/create/page.tsx
+++ b/src/app/admin/events/create/page.tsx
@@ -55,44 +55,6 @@ export default function Page() {
   const [eventName, setEventName] = useState("");
   const [selectedTemplate, setSelectedTemplate] = useState<IEventTemplate | null>(null);
   const [templates, setTemplates] = useState<IEventTemplate[]>([]);
-  /*
-  const [templates, setTemplates] = useState<IEventTemplate[]>([
-    {
-      _id: "1",
-      eventName: "Volunteer Meetup",
-      eventImage: null,
-      eventType: "Volunteer",
-      location: "Central Park",
-      description: "Community service event.",
-      checklist: "Bring gloves, trash bags",
-      groupsOnly: false,
-      wheelchairAccessible: true,
-      spanishSpeakingAccommodation: false,
-      startTime: new Date(),
-      endTime: new Date(),
-      volunteerEvent: true,
-      groupsAllowed: [],
-      registeredIds: [],
-    },
-    {
-      _id: "2",
-      eventName: "Charity Drive",
-      eventImage: null,
-      eventType: "Fundraiser",
-      location: "Community Hall",
-      description: "Fundraiser for local charities.",
-      checklist: "Bring donations",
-      groupsOnly: false,
-      wheelchairAccessible: true,
-      spanishSpeakingAccommodation: true,
-      startTime: new Date(),
-      endTime: new Date(),
-      volunteerEvent: false,
-      groupsAllowed: ["789"],
-      registeredIds: [],
-    },
-  ]);
-  */
   const [coverImage, setCoverImage] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [eventType, setEventType] = useState("");

--- a/src/app/api/eventtemplate/route.ts
+++ b/src/app/api/eventtemplate/route.ts
@@ -15,14 +15,12 @@ export async function POST(req: NextRequest) {
     try {
         const newEventTemplate = new Event(eventTemplate);
 
-
         const createdEventTemplate = await newEventTemplate.save();
         revalidateTag("eventTemplates");
 
-        return NextResponse.json(newEventTemplate, {
+        return NextResponse.json(createdEventTemplate, {
             status: 200,
         });
-
 
 
     } catch (err: any) {

--- a/src/app/api/eventtemplate/route.ts
+++ b/src/app/api/eventtemplate/route.ts
@@ -43,3 +43,20 @@ export async function POST(req: NextRequest) {
     }
 
 }
+
+// GET ALL EVENT TEMPLATES
+export async function GET(req: NextRequest) {
+    await connectDB();
+
+    try {
+        const eventTemplates = await Event.findById({}).orFail();
+        return NextResponse.json(eventTemplates);
+    } catch (err: any) {
+        return NextResponse.json(
+            "No event templates found " + err, 
+            {status: 404}
+        )
+    }
+
+
+}

--- a/src/app/api/eventtemplate/route.ts
+++ b/src/app/api/eventtemplate/route.ts
@@ -49,7 +49,7 @@ export async function GET(req: NextRequest) {
     await connectDB();
 
     try {
-        const eventTemplates = await Event.findById({}).orFail();
+        const eventTemplates = await Event.find({}).orFail();
         return NextResponse.json(eventTemplates);
     } catch (err: any) {
         return NextResponse.json(
@@ -57,6 +57,5 @@ export async function GET(req: NextRequest) {
             {status: 404}
         )
     }
-
 
 }


### PR DESCRIPTION
## Developer: Brady Welsh

Closes #265 

### Pull Request Summary

The create event page now correctly calls the backend function to interact with event templates correctly. In addition, a GET route was created in the backend to get all event templates

### Modifications

- api/eventtemplate/route.ts - GET request created to get all event templates.
- app/admin/events/create/page.tsx - now uses the GET call to get all event templates for the dropdown bar. Now uses the POST call to save an event template when the user clicks on the "Save as Template" button.

### Testing Considerations

- I've tested to make sure that the calls work the right way, when clicking "Save as Template" the template is saved in the DB (checked in Mongo) and the GET call was easy to test as the dropdown shows all templates currently in the DB.
