### PR TITLE
Update Filters on Event Management Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
                 "mongodb": "^6.5.0",
                 "mongoose": "^7.6.11",
                 "next": "^14.2.3",
+                "nextjs-app-template": "file:",
                 "nodemailer": "^6.9.13",
                 "npm": "^10.7.0",
                 "postcss": "^8.4.38",
@@ -10071,6 +10072,10 @@
             "engines": {
                 "node": "^10 || ^12 || >=14"
             }
+        },
+        "node_modules/nextjs-app-template": {
+            "resolved": "",
+            "link": true
         },
         "node_modules/no-case": {
             "version": "3.0.4",

--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -41,6 +41,8 @@ const EventPreview = () => {
   const [beaverWalk, setBeaverWalk] = useState(false);
   const [festivals, setFestivals] = useState(false);
   const [pondCleanup, setPondCleanup] = useState(false);
+  const [minHeadcount, setMinHeadcount] = useState<number | null>(null);
+  const [maxHeadcount, setMaxHeadcount] = useState<number | null>(null);
 
   // get string for some group based on id
   const fetchGroupName = async (groupId: string): Promise<string> => {
@@ -104,6 +106,12 @@ const EventPreview = () => {
         wheelchairAccessible ? event.wheelchairAccessible : true
       )
       .filter((event) => (groupOnly ? event.groupsOnly : true))
+      .filter((event) => {
+        const headcount = event.registeredIds?.length || 0;
+        if (minHeadcount !== null && headcount < minHeadcount) return false;
+        if (maxHeadcount !== null && headcount > maxHeadcount) return false;
+        return true;
+      })
       .filter((event) => {
         // display event if the checkbox is toggled and event type is toggled
         // if multiple checkboxes are toggled, display events for any of the types that are toggled
@@ -227,95 +235,119 @@ const EventPreview = () => {
         </div>
         <div className={style.filterGroupContainer}>
           <div className={style.filterContainer}>
-            <div className={style.filterHeader}>Event Timeframe</div>
-            <CheckboxGroup colorScheme="green" defaultValue={["true"]}>
-              <Stack spacing={[1, 5]} direction={["column", "column"]} ml="1.5">
-                {/** isChecked property does not work inside of CheckBoxGroup. Instead, set defaultValue == value */}
-                <Checkbox
-                  value="true"
-                  colorScheme="blue"
-                  onChange={() => setShowFutureEvents(!showFutureEvents)}
-                >
-                  <div className={style.checkboxLabel}>Future Events</div>
-                </Checkbox>
-                <Checkbox
-                  value="false"
-                  colorScheme="blue"
-                  onChange={() => setShowPastEvents(!showPastEvents)}
-                >
-                  <div className={style.checkboxLabel}>Past Events</div>
-                </Checkbox>
-              </Stack>
-            </CheckboxGroup>
+            <div className={style.filterHeader}>Headcount Range</div>
+            <Stack spacing={2} ml="1">
+              <Input
+                type="number"
+                placeholder="Minimum Headcount"
+                value={minHeadcount ?? ""}
+                onChange={(e) =>
+                  setMinHeadcount(
+                    e.target.value ? parseInt(e.target.value) : null
+                  )
+                }
+                size="sm"
+                borderColor="black"
+              />
+              <Input
+                type="number"
+                placeholder="Maximum Headcount"
+                value={maxHeadcount ?? ""}
+                onChange={(e) =>
+                  setMaxHeadcount(
+                    e.target.value ? parseInt(e.target.value) : null
+                  )
+                }
+                size="sm"
+                borderColor="black"
+              />
+            </Stack>
           </div>
-          <div className={style.filterContainerTypeAccessibility}>
-            <div className={style.filterHeader}>Event Type</div>
-            <CheckboxGroup colorScheme="green" defaultValue={[]}>
-              <Stack spacing={[1, 5]} direction={["column", "column"]} ml="1.5">
-                <Checkbox
-                  value="beaver walk"
-                  colorScheme="teal"
-                  onChange={() => setBeaverWalk(!beaverWalk)}
-                >
-                  <div className={style.checkboxLabel}>Beaver Walk</div>
-                </Checkbox>
-                <Checkbox
-                  value="volunteer"
-                  colorScheme="yellow"
-                  onChange={() => setVolunteerEvents(!volunteerEvents)}
-                >
-                  <div className={style.checkboxLabel}>Volunteer</div>
-                </Checkbox>
-                <Checkbox
-                  value="festivals"
-                  colorScheme="green"
-                  onChange={() => setFestivals(!festivals)}
-                >
-                  <div className={style.checkboxLabel}>Festivals</div>
-                </Checkbox>
-                <Checkbox
-                  value="pond clean up"
-                  colorScheme="red"
-                  onChange={() => setPondCleanup(!pondCleanup)}
-                >
-                  <div className={style.checkboxLabel}>Pond Clean Up</div>
-                </Checkbox>
-              </Stack>
-            </CheckboxGroup>
-          </div>
-          <div className={style.filterContainerTypeAccessibility}>
-            <div className={style.filterHeader}>Accessibility</div>
-            <CheckboxGroup colorScheme="green" defaultValue={[]}>
-              <Stack spacing={[1, 5]} direction={["column", "column"]} ml="1.5">
-                <Checkbox
-                  value="spanish"
-                  colorScheme="blue"
-                  onChange={() => setSpanishSpeakingOnly(!spanishSpeakingOnly)}
-                >
-                  <div className={style.checkboxLabel}>Spanish Speaking</div>
-                </Checkbox>
-                <Checkbox
-                  value="wheelchair accessible"
-                  colorScheme="blue"
-                  onChange={() =>
-                    setWheelchairAccessible(!wheelchairAccessible)
-                  }
-                >
-                  <div className={style.checkboxLabel}>
-                    Wheelchair Accessible
-                  </div>
-                </Checkbox>
-                <Checkbox
-                  value="group only"
-                  colorScheme="blue"
-                  onChange={() => setGroupOnly(!groupOnly)}
-                >
-                  <div className={style.checkboxLabel}>Group Only</div>
-                </Checkbox>
-              </Stack>
-            </CheckboxGroup>
-          </div>
+          <div className={style.filterHeader}>Event Timeframe</div>
+          <CheckboxGroup colorScheme="green" defaultValue={["true"]}>
+            <Stack spacing={[1, 5]} direction={["column", "column"]} ml="1.5">
+              {/** isChecked property does not work inside of CheckBoxGroup. Instead, set defaultValue == value */}
+              <Checkbox
+                value="true"
+                colorScheme="blue"
+                onChange={() => setShowFutureEvents(!showFutureEvents)}
+              >
+                <div className={style.checkboxLabel}>Future Events</div>
+              </Checkbox>
+              <Checkbox
+                value="false"
+                colorScheme="blue"
+                onChange={() => setShowPastEvents(!showPastEvents)}
+              >
+                <div className={style.checkboxLabel}>Past Events</div>
+              </Checkbox>
+            </Stack>
+          </CheckboxGroup>
         </div>
+        <div className={style.filterContainerTypeAccessibility}>
+          <div className={style.filterHeader}>Event Type</div>
+          <CheckboxGroup colorScheme="green" defaultValue={[]}>
+            <Stack spacing={[1, 5]} direction={["column", "column"]} ml="1.5">
+              <Checkbox
+                value="beaver walk"
+                colorScheme="teal"
+                onChange={() => setBeaverWalk(!beaverWalk)}
+              >
+                <div className={style.checkboxLabel}>Beaver Walk</div>
+              </Checkbox>
+              <Checkbox
+                value="volunteer"
+                colorScheme="yellow"
+                onChange={() => setVolunteerEvents(!volunteerEvents)}
+              >
+                <div className={style.checkboxLabel}>Volunteer</div>
+              </Checkbox>
+              <Checkbox
+                value="festivals"
+                colorScheme="green"
+                onChange={() => setFestivals(!festivals)}
+              >
+                <div className={style.checkboxLabel}>Festivals</div>
+              </Checkbox>
+              <Checkbox
+                value="pond clean up"
+                colorScheme="red"
+                onChange={() => setPondCleanup(!pondCleanup)}
+              >
+                <div className={style.checkboxLabel}>Pond Clean Up</div>
+              </Checkbox>
+            </Stack>
+          </CheckboxGroup>
+        </div>
+        <div className={style.filterContainerTypeAccessibility}>
+          <div className={style.filterHeader}>Accessibility</div>
+          <CheckboxGroup colorScheme="green" defaultValue={[]}>
+            <Stack spacing={[1, 5]} direction={["column", "column"]} ml="1.5">
+              <Checkbox
+                value="spanish"
+                colorScheme="blue"
+                onChange={() => setSpanishSpeakingOnly(!spanishSpeakingOnly)}
+              >
+                <div className={style.checkboxLabel}>Spanish Speaking</div>
+              </Checkbox>
+              <Checkbox
+                value="wheelchair accessible"
+                colorScheme="blue"
+                onChange={() => setWheelchairAccessible(!wheelchairAccessible)}
+              >
+                <div className={style.checkboxLabel}>Wheelchair Accessible</div>
+              </Checkbox>
+              <Checkbox
+                value="group only"
+                colorScheme="blue"
+                onChange={() => setGroupOnly(!groupOnly)}
+              >
+                <div className={style.checkboxLabel}>Group Only</div>
+              </Checkbox>
+            </Stack>
+          </CheckboxGroup>
+        </div>
+        <div className={style.filterContainerTypeAccessibility}></div>
       </aside>
       {loading ? (
         <div className={style.cardContainer}>

--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -31,6 +31,7 @@ const EventPreview = () => {
   });
   const [spanishSpeakingOnly, setSpanishSpeakingOnly] = useState(false);
   const [wheelchairAccessible, setWheelchairAccessible] = useState(false);
+  const [groupOnly, setGroupOnly] = useState(false);
   const [showPastEvents, setShowPastEvents] = useState(false);
   const [showFutureEvents, setShowFutureEvents] = useState(true);
   const [loading, setLoading] = useState(true);
@@ -102,6 +103,7 @@ const EventPreview = () => {
       .filter((event) =>
         wheelchairAccessible ? event.wheelchairAccessible : true
       )
+      .filter((event) => (groupOnly ? event.groupsOnly : true))
       .filter((event) => {
         // display event if the checkbox is toggled and event type is toggled
         // if multiple checkboxes are toggled, display events for any of the types that are toggled
@@ -302,6 +304,13 @@ const EventPreview = () => {
                   <div className={style.checkboxLabel}>
                     Wheelchair Accessible
                   </div>
+                </Checkbox>
+                <Checkbox
+                  value="group only"
+                  colorScheme="blue"
+                  onChange={() => setGroupOnly(!groupOnly)}
+                >
+                  <div className={style.checkboxLabel}>Group Only</div>
                 </Checkbox>
               </Stack>
             </CheckboxGroup>

--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -14,7 +14,7 @@ import {
   Stack,
   Text,
   Box,
-  Input
+  Input,
 } from "@chakra-ui/react";
 import Select from "react-select";
 import { useEventsAscending } from "app/lib/swrfunctions";
@@ -22,12 +22,12 @@ import "../../fonts/fonts.css";
 
 const EventPreview = () => {
   //states
-  const {events, isLoading} = useEventsAscending()
+  const { events, isLoading } = useEventsAscending();
   const [groupNames, setGroupNames] = useState<{ [key: string]: string }>({});
   const [searchTerm, setSearchTerm] = useState("");
-  const [sortOrder, setSortOrder] = useState<{ value: string; label: string}>({
+  const [sortOrder, setSortOrder] = useState<{ value: string; label: string }>({
     value: "earliest",
-    label: "From Earliest"
+    label: "From Earliest",
   });
   const [spanishSpeakingOnly, setSpanishSpeakingOnly] = useState(false);
   const [wheelchairAccessible, setWheelchairAccessible] = useState(false);
@@ -37,9 +37,9 @@ const EventPreview = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedEvent, setSelectedEvent] = useState<IEvent | null>(null);
   const [volunteerEvents, setVolunteerEvents] = useState(false);
-  const [wateryWalk, setWateryWalk] = useState(false);
-  const [specialEvents, setSpecialEvents] = useState(false);
-
+  const [beaverWalk, setBeaverWalk] = useState(false);
+  const [festivals, setFestivals] = useState(false);
+  const [pondCleanup, setPondCleanup] = useState(false);
 
   // get string for some group based on id
   const fetchGroupName = async (groupId: string): Promise<string> => {
@@ -62,8 +62,8 @@ const EventPreview = () => {
   useEffect(() => {
     const fetchEvents = async () => {
       try {
-        if (!events){
-            return
+        if (!events) {
+          return;
         }
         const names: { [key: string]: string } = {};
         setLoading(true);
@@ -94,54 +94,61 @@ const EventPreview = () => {
   };
 
   // filtering events logic
-  const filteredEvents = events
-    ?.filter((event) =>
-      spanishSpeakingOnly ? event.spanishSpeakingAccommodation : true
-    )
-    .filter((event) =>
-      wheelchairAccessible ? event.wheelchairAccessible : true
-    )
-    .filter((event) => {
-      // display event if the checkbox is toggled and event type is toggled
-      // if multiple checkboxes are toggled, display events for any of the types that are toggled
-      if ((volunteerEvents && event.eventType === "Volunteer") ||
-         (wateryWalk && event.eventType === "Watery Walk") ||
-         (specialEvents && event.eventType === "Special Events")) 
-        {
-         return true;
+  const filteredEvents =
+    events
+      ?.filter((event) =>
+        spanishSpeakingOnly ? event.spanishSpeakingAccommodation : true
+      )
+      .filter((event) =>
+        wheelchairAccessible ? event.wheelchairAccessible : true
+      )
+      .filter((event) => {
+        // display event if the checkbox is toggled and event type is toggled
+        // if multiple checkboxes are toggled, display events for any of the types that are toggled
+        if (
+          (volunteerEvents && event.eventType === "Volunteer") ||
+          (beaverWalk && event.eventType === "Beaver Walk") ||
+          (festivals && event.eventType === "Festival") ||
+          (pondCleanup && event.eventType === "Pond Clean Up")
+        ) {
+          return true;
         }
-      // if none of the checkboxes are toggled, display all events
-      else if (!volunteerEvents && !wateryWalk && !specialEvents )
-        {
-         return true;
+        // if none of the checkboxes are toggled, display all events
+        else if (
+          !volunteerEvents &&
+          !beaverWalk &&
+          !festivals &&
+          !pondCleanup
+        ) {
+          return true;
         }
       })
-        
-    .filter((event) => {
-      const eventDate = new Date(event.startTime);
-      const now = new Date();
-      if (showFutureEvents && showPastEvents) {
+
+      .filter((event) => {
+        const eventDate = new Date(event.startTime);
+        const now = new Date();
+        if (showFutureEvents && showPastEvents) {
+          return true;
+        } else if (showFutureEvents) {
+          return eventDate >= now;
+        } else if (showPastEvents) {
+          return eventDate <= now;
+        }
         return true;
-      } else if (showFutureEvents) {
-        return eventDate >= now;
-      } else if (showPastEvents) {
-        return eventDate <= now;
-      }
-      return true;
-    })
-    .filter((event) =>
-      event.eventName.toLowerCase().includes(searchTerm.toLowerCase())
-    )
-    .sort((a, b) =>
-      sortOrder.value === "earliest"  // Check This!
-        ? new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
-        : new Date(b.startTime).getTime() - new Date(a.startTime).getTime()
-    ) || [];
+      })
+      .filter((event) =>
+        event.eventName.toLowerCase().includes(searchTerm.toLowerCase())
+      )
+      .sort((a, b) =>
+        sortOrder.value === "earliest" // Check This!
+          ? new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
+          : new Date(b.startTime).getTime() - new Date(a.startTime).getTime()
+      ) || [];
   const sortOptions = [
     { value: "earliest", label: "From Earliest" },
-    { value: "latest", label: "From Latest" }
+    { value: "latest", label: "From Latest" },
   ];
-  
+
   return (
     <div className={style.mainContainer}>
       <aside className={style.sidebar}>
@@ -159,7 +166,7 @@ const EventPreview = () => {
               focusBorderColor="#337774"
               borderColor="#337774"
               borderWidth="1.5px"
-              _hover={{ borderColor: '#337774' }}
+              _hover={{ borderColor: "#337774" }}
             />
             <MagnifyingGlassIcon
               style={{
@@ -169,7 +176,7 @@ const EventPreview = () => {
                 margin: "auto",
                 bottom: "10px",
                 right: "10px",
-                color: "#337774"
+                color: "#337774",
               }}
             />
           </div>
@@ -179,10 +186,13 @@ const EventPreview = () => {
               value={sortOrder}
               options={sortOptions}
               onChange={(selectedOption) =>
-              setSortOrder(
-              selectedOption || { value: "earliest", label: "From Earliest" }
-                      )
-                    }     
+                setSortOrder(
+                  selectedOption || {
+                    value: "earliest",
+                    label: "From Earliest",
+                  }
+                )
+              }
               className={style.sortSelect}
               isClearable={false}
               isSearchable={false}
@@ -191,45 +201,48 @@ const EventPreview = () => {
                   ...provided,
                   borderRadius: "12px",
                   height: "40px",
-                  width: "200px"
-                }),      
+                  width: "200px",
+                }),
                 singleValue: (provided) => ({
                   ...provided,
-                  color: "black"
+                  color: "black",
                 }),
                 option: (provided, state) => ({
                   ...provided,
-                  color: state.isSelected ? "white" : "black"
+                  color: state.isSelected ? "white" : "black",
                 }),
                 placeholder: (provided) => ({
                   ...provided,
-                  color: "black"
+                  color: "black",
                 }),
                 menu: (provided) => ({
                   ...provided,
-                  width: "150px"
-                })
-              }}    
-            >
-            </Select>      
+                  width: "150px",
+                }),
+              }}
+            ></Select>
           </div>
-          
         </div>
         <div className={style.filterGroupContainer}>
           <div className={style.filterContainer}>
             <div className={style.filterHeader}>Event Timeframe</div>
             <CheckboxGroup colorScheme="green" defaultValue={["true"]}>
               <Stack spacing={[1, 5]} direction={["column", "column"]} ml="1.5">
-                  {/** isChecked property does not work inside of CheckBoxGroup. Instead, set defaultValue == value */}
-                <Checkbox value="true" colorScheme="blue"
-                  onChange={() => setShowFutureEvents(!showFutureEvents)}>
-                    <div className={style.checkboxLabel}>Future Events</div>
+                {/** isChecked property does not work inside of CheckBoxGroup. Instead, set defaultValue == value */}
+                <Checkbox
+                  value="true"
+                  colorScheme="blue"
+                  onChange={() => setShowFutureEvents(!showFutureEvents)}
+                >
+                  <div className={style.checkboxLabel}>Future Events</div>
                 </Checkbox>
-                <Checkbox value="false" colorScheme="blue"
-                  onChange={() => setShowPastEvents(!showPastEvents)}>
-                    <div className={style.checkboxLabel}>Past Events</div>
+                <Checkbox
+                  value="false"
+                  colorScheme="blue"
+                  onChange={() => setShowPastEvents(!showPastEvents)}
+                >
+                  <div className={style.checkboxLabel}>Past Events</div>
                 </Checkbox>
-               
               </Stack>
             </CheckboxGroup>
           </div>
@@ -237,17 +250,33 @@ const EventPreview = () => {
             <div className={style.filterHeader}>Event Type</div>
             <CheckboxGroup colorScheme="green" defaultValue={[]}>
               <Stack spacing={[1, 5]} direction={["column", "column"]} ml="1.5">
-                <Checkbox value="watery walk" colorScheme="teal"
-                  onChange={() => setWateryWalk(!wateryWalk)}>
-                    <div className={style.checkboxLabel}>Watery Walk</div>
+                <Checkbox
+                  value="beaver walk"
+                  colorScheme="teal"
+                  onChange={() => setBeaverWalk(!beaverWalk)}
+                >
+                  <div className={style.checkboxLabel}>Beaver Walk</div>
                 </Checkbox>
-                <Checkbox value="volunteer" colorScheme="yellow"
-                  onChange={() => setVolunteerEvents(!volunteerEvents)}>
-                    <div className={style.checkboxLabel}>Volunteer</div>
+                <Checkbox
+                  value="volunteer"
+                  colorScheme="yellow"
+                  onChange={() => setVolunteerEvents(!volunteerEvents)}
+                >
+                  <div className={style.checkboxLabel}>Volunteer</div>
                 </Checkbox>
-                <Checkbox value="special events" colorScheme="green"
-                  onChange={() => setSpecialEvents(!specialEvents)}>
-                    <div className={style.checkboxLabel}>Special Events</div>
+                <Checkbox
+                  value="festivals"
+                  colorScheme="green"
+                  onChange={() => setFestivals(!festivals)}
+                >
+                  <div className={style.checkboxLabel}>Festivals</div>
+                </Checkbox>
+                <Checkbox
+                  value="pond clean up"
+                  colorScheme="red"
+                  onChange={() => setPondCleanup(!pondCleanup)}
+                >
+                  <div className={style.checkboxLabel}>Pond Clean Up</div>
                 </Checkbox>
               </Stack>
             </CheckboxGroup>
@@ -256,25 +285,33 @@ const EventPreview = () => {
             <div className={style.filterHeader}>Accessibility</div>
             <CheckboxGroup colorScheme="green" defaultValue={[]}>
               <Stack spacing={[1, 5]} direction={["column", "column"]} ml="1.5">
-
-                <Checkbox value="spanish" colorScheme="blue"
-                  onChange={() => setSpanishSpeakingOnly(!spanishSpeakingOnly)}>
-                    <div className={style.checkboxLabel}>Spanish Speaking</div>
+                <Checkbox
+                  value="spanish"
+                  colorScheme="blue"
+                  onChange={() => setSpanishSpeakingOnly(!spanishSpeakingOnly)}
+                >
+                  <div className={style.checkboxLabel}>Spanish Speaking</div>
                 </Checkbox>
-                <Checkbox value="wheelchair accessible" colorScheme="blue"
-                  onChange={() => setWheelchairAccessible(!wheelchairAccessible)}>
-                    <div className={style.checkboxLabel}>Wheelchair Accessible</div>
+                <Checkbox
+                  value="wheelchair accessible"
+                  colorScheme="blue"
+                  onChange={() =>
+                    setWheelchairAccessible(!wheelchairAccessible)
+                  }
+                >
+                  <div className={style.checkboxLabel}>
+                    Wheelchair Accessible
+                  </div>
                 </Checkbox>
               </Stack>
             </CheckboxGroup>
           </div>
-        </div> 
-        
+        </div>
       </aside>
       {loading ? (
         <div className={style.cardContainer}>
           <Text fontFamily="Lato" fontSize="2xl" mt="5%" textAlign="center">
-          Loading Events...
+            Loading Events...
           </Text>
         </div>
       ) : filteredEvents.length > 0 ? (
@@ -283,11 +320,12 @@ const EventPreview = () => {
             {filteredEvents.map((event) => (
               <li key={event._id} className={style.eventItem}>
                 <Link href={"/admin/events/edit/" + event._id}>
-                    <EventPreviewComponent
+                  <EventPreviewComponent
                     event={event}
                     groupName={groupNames[event._id]}
                     onClick={() => handleEventClick(event)}
-                /></Link>
+                  />
+                </Link>
               </li>
             ))}
           </ul>
@@ -296,7 +334,7 @@ const EventPreview = () => {
         <div className={style.cardContainer}>
           <Text fontFamily="Lato" fontSize="2xl" mt="10%" textAlign="center">
             No Events Found
-          </Text>        
+          </Text>
         </div>
       )}
       {selectedEvent && (

--- a/src/app/components/CreateEvent.tsx
+++ b/src/app/components/CreateEvent.tsx
@@ -1,269 +1,268 @@
 import {
-    Modal,
-    ModalOverlay,
-    ModalContent,
-    ModalHeader,
-    ModalFooter,
-    ModalBody,
-    ModalCloseButton,
-    useDisclosure,
-    Input,
-    Textarea,
-    Select,
-    Switch,
-    Stack,
-    FormControl,
-    FormLabel,
-  } from "@chakra-ui/react";
-  import { Button } from "@styles/Button";
-  import React, { useState } from "react";
-  
-  const CreateEvent = () => {
-    const { isOpen, onOpen, onClose } = useDisclosure(); // button open/close
-  
-    const [name, setName] = useState("");
-    const [loc, setLoc] = useState("");
-    const [date, setDate] = useState("");
-    const [start, setStart] = useState("");
-    const [end, setEnd] = useState("");
-    const [desc, setDesc] = useState("");
-    const [type, setType] = useState("");
-    const [vol, setVol] = useState(false);
-    const [myGrp, setMyGrp] = useState(false);
-    const [wc, setWC] = useState(false);
-    const [span, setSpan] = useState(false);
-  
-    const handleNameChange = (e: any) => setName(e.target.value);
-    const handleLocationChange = (e: any) => setLoc(e.target.value);
-    const handleDateChange = (e: any) => setDate(e.target.value);
-    const handleStartChange = (e: any) => setStart(e.target.value);
-    const handleEndChange = (e: any) => setEnd(e.target.value);
-    const handleDescChange = (e: any) => setDesc(e.target.value);
-    const handleTypeChange = (e: any) => setType(e.target.value);
-    const handleVolChange = () => {
-      setVol(!vol);
-      if (vol) {
-        setMyGrp(false);
-      }
-    };
-    const handleMyGrp = () => setMyGrp(!myGrp);
-    const handleWCChange = () => setWC(!wc);
-    const handleSpanChange = () => setSpan(!span);
-  
-    const [isSubmitted, setIsSubmitted] = useState(false);
-  
-    function HandleClose() {
-      setName("");
-      setLoc("");
-      setDate("");
-      setStart("");
-      setEnd("");
-      setDesc("");
-      setType("");
-      setVol(false);
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+  useDisclosure,
+  Input,
+  Textarea,
+  Select,
+  Switch,
+  Stack,
+  FormControl,
+  FormLabel,
+} from "@chakra-ui/react";
+import { Button } from "@styles/Button";
+import React, { useState } from "react";
+
+const CreateEvent = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure(); // button open/close
+
+  const [name, setName] = useState("");
+  const [loc, setLoc] = useState("");
+  const [date, setDate] = useState("");
+  const [start, setStart] = useState("");
+  const [end, setEnd] = useState("");
+  const [desc, setDesc] = useState("");
+  const [type, setType] = useState("");
+  const [vol, setVol] = useState(false);
+  const [myGrp, setMyGrp] = useState(false);
+  const [wc, setWC] = useState(false);
+  const [span, setSpan] = useState(false);
+
+  const handleNameChange = (e: any) => setName(e.target.value);
+  const handleLocationChange = (e: any) => setLoc(e.target.value);
+  const handleDateChange = (e: any) => setDate(e.target.value);
+  const handleStartChange = (e: any) => setStart(e.target.value);
+  const handleEndChange = (e: any) => setEnd(e.target.value);
+  const handleDescChange = (e: any) => setDesc(e.target.value);
+  const handleTypeChange = (e: any) => setType(e.target.value);
+  const handleVolChange = () => {
+    setVol(!vol);
+    if (vol) {
       setMyGrp(false);
-      setWC(false);
-      setSpan(false);
-      setIsSubmitted(false);
-      onClose();
     }
-  
-    function HandleSubmit() {
-      const eventData = {
-        eventName: name,
-        location: loc,
-        description: desc,
-        wheelchairAccessible: wc,
-        spanishSpeakingAccommodation: span,
-        startTime: new Date(`${date}T${start}`),
-        endTime: new Date(`${date}T${end}`),
-        volunteerEvent: vol,
-        groupsAllowed: myGrp ? [] : null,
-        registeredIds: [],
-      };
-  
-      
-  
-      fetch("/api/events", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(eventData),
-      })
-        .then((response) => {
-          if (!response.ok) {
-            throw new Error("Failed to create event");
-          }
-          setIsSubmitted(true);
-          HandleClose();
-        })
-        .catch((error) => {
-          console.error("Error creating event:", error.message);
-        });
-    }
-  
-    return (
-      <>
-        <Button onClick={onOpen}>Create Event</Button>
-  
-        <Modal isOpen={isOpen} onClose={HandleClose} size="xl">
-          <ModalOverlay />
-          <ModalContent>
-            <ModalHeader bg="#a3caf0" fontWeight="bold" position="relative">
-              Create Event
-            </ModalHeader>
-            <ModalCloseButton size="l" />
-  
-            <ModalBody>
-              <Stack spacing={3}>
-                <FormControl isInvalid={name === "" && isSubmitted}>
-                  <Input
-                    variant="flushed"
-                    placeholder="Event Name"
-                    fontWeight="bold"
-                    value={name}
-                    onChange={handleNameChange}
-                  />
-                </FormControl>
-  
-                <FormControl isInvalid={loc === "" && isSubmitted}>
-                  <Input
-                    variant="flushed"
-                    placeholder="Event Location"
-                    fontWeight="bold"
-                    value={loc}
-                    onChange={handleLocationChange}
-                  />
-                </FormControl>
-  
-                <Stack spacing={0}>
-                  <FormControl isInvalid={date === "" && isSubmitted}>
-                    <FormLabel color="grey" fontWeight="bold">
-                      Event Date
-                    </FormLabel>
-                    <Input
-                      placeholder="Select Date"
-                      size="md"
-                      type="date"
-                      color="grey"
-                      value={date}
-                      onChange={handleDateChange}
-                    />
-                  </FormControl>
-                </Stack>
-  
-                <Stack spacing={0}>
-                  <FormControl isInvalid={start === "" && isSubmitted}>
-                    <FormLabel color="grey" fontWeight="bold">
-                      Start Time
-                    </FormLabel>
-                    <Input
-                      placeholder="Select Time"
-                      size="md"
-                      type="time"
-                      color="grey"
-                      value={start}
-                      onChange={handleStartChange}
-                    />
-                  </FormControl>
-                </Stack>
-  
-                <Stack spacing={0}>
-                  <FormControl isInvalid={end === "" && isSubmitted}>
-                    <FormLabel color="grey" fontWeight="bold">
-                      End Time
-                    </FormLabel>
-                    <Input
-                      placeholder="Select Time"
-                      size="md"
-                      type="time"
-                      color="grey"
-                      value={end}
-                      onChange={handleEndChange}
-                    />
-                  </FormControl>
-                </Stack>
-  
-                <Stack spacing={0}>
-                  <FormControl isInvalid={desc === "" && isSubmitted}>
-                    <FormLabel color="grey" fontWeight="bold">
-                      Event Description
-                    </FormLabel>
-                    <Textarea
-                      placeholder="Event Description"
-                      value={desc}
-                      onChange={handleDescChange}
-                    />
-                  </FormControl>
-                </Stack>
-  
-                <Stack spacing={0}>
-                  <FormControl isInvalid={type === "" && isSubmitted}>
-                    <FormLabel color="grey" fontWeight="bold">
-                      Event Type
-                    </FormLabel>
-                    <Select
-                      placeholder="Select option"
-                      color="grey"
-                      value={type}
-                      onChange={handleTypeChange}
-                    >
-                      <option value="option1">Watery Walk</option>
-                      <option value="option2">Pond Clean Up</option>
-                      <option value="option3">Habitat Monitoring</option>
-                    </Select>
-                  </FormControl>
-                </Stack>
-  
-                <Switch
-                  fontWeight="bold"
-                  color="grey"
-                  isChecked={vol}
-                  onChange={handleVolChange}
-                >
-                  Volunteer Event
-                </Switch>
-  
-                <Switch
-                  fontWeight="bold"
-                  color="grey"
-                  isDisabled={!vol}
-                  isFocusable={!vol}
-                  isChecked={myGrp}
-                  onChange={handleMyGrp}
-                >
-                  Only My Group Allowed
-                </Switch>
-  
-                <Switch
-                  fontWeight="bold"
-                  color="grey"
-                  isChecked={wc}
-                  onChange={handleWCChange}
-                >
-                  Wheelchair Accessibility
-                </Switch>
-  
-                <Switch
-                  fontWeight="bold"
-                  color="grey"
-                  isChecked={span}
-                  onChange={handleSpanChange}
-                >
-                  Spanish Speaking Accommodations
-                </Switch>
-              </Stack>
-            </ModalBody>
-  
-            <ModalFooter>
-              <Button onClick={HandleClose}>Close</Button>
-              <Button onClick={HandleSubmit}>Create</Button>
-            </ModalFooter>
-          </ModalContent>
-        </Modal>
-      </>
-    );
   };
-  
-  export default CreateEvent;
+  const handleMyGrp = () => setMyGrp(!myGrp);
+  const handleWCChange = () => setWC(!wc);
+  const handleSpanChange = () => setSpan(!span);
+
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  function HandleClose() {
+    setName("");
+    setLoc("");
+    setDate("");
+    setStart("");
+    setEnd("");
+    setDesc("");
+    setType("");
+    setVol(false);
+    setMyGrp(false);
+    setWC(false);
+    setSpan(false);
+    setIsSubmitted(false);
+    onClose();
+  }
+
+  function HandleSubmit() {
+    const eventData = {
+      eventName: name,
+      location: loc,
+      description: desc,
+      wheelchairAccessible: wc,
+      spanishSpeakingAccommodation: span,
+      startTime: new Date(`${date}T${start}`),
+      endTime: new Date(`${date}T${end}`),
+      volunteerEvent: vol,
+      groupsAllowed: myGrp ? [] : null,
+      registeredIds: [],
+    };
+
+    fetch("/api/events", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(eventData),
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Failed to create event");
+        }
+        setIsSubmitted(true);
+        HandleClose();
+      })
+      .catch((error) => {
+        console.error("Error creating event:", error.message);
+      });
+  }
+
+  return (
+    <>
+      <Button onClick={onOpen}>Create Event</Button>
+
+      <Modal isOpen={isOpen} onClose={HandleClose} size="xl">
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader bg="#a3caf0" fontWeight="bold" position="relative">
+            Create Event
+          </ModalHeader>
+          <ModalCloseButton size="l" />
+
+          <ModalBody>
+            <Stack spacing={3}>
+              <FormControl isInvalid={name === "" && isSubmitted}>
+                <Input
+                  variant="flushed"
+                  placeholder="Event Name"
+                  fontWeight="bold"
+                  value={name}
+                  onChange={handleNameChange}
+                />
+              </FormControl>
+
+              <FormControl isInvalid={loc === "" && isSubmitted}>
+                <Input
+                  variant="flushed"
+                  placeholder="Event Location"
+                  fontWeight="bold"
+                  value={loc}
+                  onChange={handleLocationChange}
+                />
+              </FormControl>
+
+              <Stack spacing={0}>
+                <FormControl isInvalid={date === "" && isSubmitted}>
+                  <FormLabel color="grey" fontWeight="bold">
+                    Event Date
+                  </FormLabel>
+                  <Input
+                    placeholder="Select Date"
+                    size="md"
+                    type="date"
+                    color="grey"
+                    value={date}
+                    onChange={handleDateChange}
+                  />
+                </FormControl>
+              </Stack>
+
+              <Stack spacing={0}>
+                <FormControl isInvalid={start === "" && isSubmitted}>
+                  <FormLabel color="grey" fontWeight="bold">
+                    Start Time
+                  </FormLabel>
+                  <Input
+                    placeholder="Select Time"
+                    size="md"
+                    type="time"
+                    color="grey"
+                    value={start}
+                    onChange={handleStartChange}
+                  />
+                </FormControl>
+              </Stack>
+
+              <Stack spacing={0}>
+                <FormControl isInvalid={end === "" && isSubmitted}>
+                  <FormLabel color="grey" fontWeight="bold">
+                    End Time
+                  </FormLabel>
+                  <Input
+                    placeholder="Select Time"
+                    size="md"
+                    type="time"
+                    color="grey"
+                    value={end}
+                    onChange={handleEndChange}
+                  />
+                </FormControl>
+              </Stack>
+
+              <Stack spacing={0}>
+                <FormControl isInvalid={desc === "" && isSubmitted}>
+                  <FormLabel color="grey" fontWeight="bold">
+                    Event Description
+                  </FormLabel>
+                  <Textarea
+                    placeholder="Event Description"
+                    value={desc}
+                    onChange={handleDescChange}
+                  />
+                </FormControl>
+              </Stack>
+
+              <Stack spacing={0}>
+                <FormControl isInvalid={type === "" && isSubmitted}>
+                  <FormLabel color="grey" fontWeight="bold">
+                    Event Type
+                  </FormLabel>
+                  <Select
+                    placeholder="Select option"
+                    color="grey"
+                    value={type}
+                    onChange={handleTypeChange}
+                  >
+                    <option value="option1">Beaver Walk</option>
+                    <option value="option2">Festival</option>
+                    <option value="option3">Volunteer</option>
+                    <option value="option4">Pond Clean Up</option>
+                  </Select>
+                </FormControl>
+              </Stack>
+
+              <Switch
+                fontWeight="bold"
+                color="grey"
+                isChecked={vol}
+                onChange={handleVolChange}
+              >
+                Volunteer Event
+              </Switch>
+
+              <Switch
+                fontWeight="bold"
+                color="grey"
+                isDisabled={!vol}
+                isFocusable={!vol}
+                isChecked={myGrp}
+                onChange={handleMyGrp}
+              >
+                Only My Group Allowed
+              </Switch>
+
+              <Switch
+                fontWeight="bold"
+                color="grey"
+                isChecked={wc}
+                onChange={handleWCChange}
+              >
+                Wheelchair Accessibility
+              </Switch>
+
+              <Switch
+                fontWeight="bold"
+                color="grey"
+                isChecked={span}
+                onChange={handleSpanChange}
+              >
+                Spanish Speaking Accommodations
+              </Switch>
+            </Stack>
+          </ModalBody>
+
+          <ModalFooter>
+            <Button onClick={HandleClose}>Close</Button>
+            <Button onClick={HandleSubmit}>Create</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+export default CreateEvent;

--- a/src/app/styles/admin/events.module.css
+++ b/src/app/styles/admin/events.module.css
@@ -1,192 +1,209 @@
 .mainContainer {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-evenly;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
 }
 
 .sidebar {
-    display: flex;
-    flex-direction: column;
-    gap: 25px;
-    width: 15vw;
+  display: flex;
+  flex-direction: column;
+  gap: 25px;
+  width: 15vw;
 }
 
 .cardContainer {
-    width: 80%;
+  width: 80%;
 }
 
 .loadingText {
-    position: absolute;
-    left: 50%;
+  position: absolute;
+  left: 50%;
 }
 
 .eventsList {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 35px;
-    padding: 0;
-    list-style: none;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 35px;
+  padding: 0;
+  list-style: none;
 }
 .createAndSearchContainer {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .yellowButton {
-    background-color: #e0af48;    
-    border: none;
-    border-radius: 20px;
-    cursor: pointer;
-    font-weight: bold;
-    font-size: 16px;
-    padding-left: 50px;
-    padding-right: 50px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-    white-space: nowrap;
+  background-color: #e0af48;
+  border: none;
+  border-radius: 20px;
+  cursor: pointer;
+  font-weight: bold;
+  font-size: 16px;
+  padding-left: 50px;
+  padding-right: 50px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  white-space: nowrap;
 }
 
 .yellowButton:hover {
-    background-color: #c19137;
-    cursor: pointer;
+  background-color: #c19137;
+  cursor: pointer;
 }
 
 .searchWrapper {
-    position: relative;
-    display: flex;
-    width: 200px;
-
+  position: relative;
+  display: flex;
+  width: 200px;
 }
 
 .searchBar {
-    font-weight: bold;
-    font-size: 16px;
-    color: #337774;
-    border: 2px solid #337774;
-    border-radius: 10px;
-    align-items: center;
-    padding-top: 5px;
-    padding-bottom: 5px;
-    padding-left: 8px;
-    padding-right: 8px;
-    margin-top: 20px;
-    margin-bottom: 0px;
+  font-weight: bold;
+  font-size: 16px;
+  color: #337774;
+  border: 2px solid #337774;
+  border-radius: 10px;
+  align-items: center;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  padding-left: 8px;
+  padding-right: 8px;
+  margin-top: 20px;
+  margin-bottom: 0px;
 }
 
 .sortSelect {
-    margin-top: 20px;
+  margin-top: 20px;
 }
 
 .filterContainer {
-    margin-top: 20px;
-    margin-bottom: 20px;
-    margin-left: 0px;
+  margin-top: 20px;
+  margin-bottom: 20px;
+  margin-left: 0px;
 }
 .filterHeader {
-    margin-left: 0px;
-    font-size: 16px;
-    font-weight: bold;
-    text-align: left;
-    margin-bottom: 20px;
-    margin-top: 20px;
+  margin-left: 0px;
+  font-size: 16px;
+  font-weight: bold;
+  text-align: left;
+  margin-bottom: 20px;
+  margin-top: 20px;
 }
 
 .checkboxLabel {
-    font-size: 15px;
-    white-space: nowrap;
+  font-size: 15px;
+  white-space: nowrap;
 }
 
 @media (max-width: 1400px) {
-    .cardContainer {
-        width: 61%;
-    }
+  .cardContainer {
+    width: 61%;
+  }
 
-    .eventsList {
-        display: grid;
-        grid-template-columns: repeat(2, 0fr);
-        gap: 35px;
-        padding: 0;
-        list-style: none;
-    }
+  .eventsList {
+    display: grid;
+    grid-template-columns: repeat(2, 0fr);
+    gap: 35px;
+    padding: 0;
+    list-style: none;
+  }
 }
 
 @media (max-width: 1200px) {
-    .mainContainer {
-        flex-direction: column;
-        gap: 20px;
-        align-items: center;
-    }
+  .mainContainer {
+    flex-direction: column;
+    gap: 20px;
+    align-items: center;
+  }
 
-    .eventsList {
-        display: grid;
-        grid-template-columns: repeat(2, 1fr);
-        gap: 35px;
-        padding: 0;
-        list-style: none;
-    }
+  .eventsList {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 35px;
+    padding: 0;
+    list-style: none;
+  }
 
-    .cardContainer {
-        width: auto;
-    }
+  .cardContainer {
+    width: auto;
+  }
 
-    .sidebar {
-        width: 100%;
-        margin-left: 0;
-        align-items: center;
-        gap: 10px;
-    }
+  .sidebar {
+    width: 100%;
+    margin-left: 0;
+    align-items: center;
+    gap: 10px;
+  }
 
-    .filterGroupContainer {
-        display: flex;
-        justify-content: space-between;
-        align-items: stretch;
-        gap: 50px;
-    }
+  .filterGroupContainer {
+    display: flex;
+    justify-content: space-between;
+    align-items: stretch;
+    gap: 50px;
+  }
 }
 
 @media (max-width: 768px) {
-    .sidebar {
-        width: 100%;
-        margin-left: 0;
-        align-items: center;
-    }
+  .sidebar {
+    width: 100%;
+    margin-left: 0;
+    align-items: center;
+  }
 
-    .eventsList {
-        grid-template-columns: 1fr;
-        align-items: center;
-    }
+  .eventsList {
+    grid-template-columns: 1fr;
+    align-items: center;
+  }
 
-    .searchBar {
-        padding: 5px;
-        font-size: 12px;
-    }
-    .filterHeader {
-        font-size: 12px;
-    }
-    .checkboxLabel {
-        font-size: 12px;
-    }
+  .searchBar {
+    padding: 5px;
+    font-size: 12px;
+  }
+  .filterHeader {
+    font-size: 12px;
+  }
+  .checkboxLabel {
+    font-size: 12px;
+  }
 
-    .checkBoxes input[type="checkbox"] {
-        margin-right: 5px;
-    }
+  .checkBoxes input[type="checkbox"] {
+    margin-right: 5px;
+  }
 }
-  
+
 @media (max-width: 570px) {
-   .filterContainerTypeAccessibility {
-        display: none;
-   }
+  .mainContainer {
+    padding-bottom: 40px;
+  }
 
-   .filterContainer{
+  .filterContainerTypeAccessibility {
+    flex-direction: column;
+    display: flex;
+    gap: 20px;
+  }
+
+  .filterContainer,
+  .filterContainerTypeAccessibility {
     margin-top: 0px;
-   }
+    width: 100%;
+    align-items: flex-start;
+  }
 
-   .filterHeader{
+  .filterHeader {
     margin-top: 0px;
-   }
+  }
 
-   .sortSelect {
+  .searchWrapper {
+    width: 100%;
+  }
+
+  .sortSelect {
     margin-bottom: 20px;
-}
+    width: 100%;
+  }
+
+  .headcount {
+    width: 50%;
+  }
 }


### PR DESCRIPTION
## Developer: Kayla Tran

Closes #247 

### Pull Request Summary

Fixing filtering of events on manage events page by ensuring the event types to filter by allign with what are available as options in creating an event. Then, adding additional filtering options: headcount and group only events. 

### Modifications

- package-lock.json: pulled and merged from main after I created branch and ran npm install
- src\app\admin\events\page.tsx: fixed event type filtering and options, added filters (css and functionality) for group only and headcount range
- src\app\components\CreateEvent.tsx: corrected the available options on the form

### Testing Considerations

- ran locally and confirmed each filter worked properly given the current events in the database
- not sure what color different event types should be (just different from each other or is there a specific color each one should be?)
- should max headcount be set to atleast equal 1 since you can input 0 
- should group only filter be its own category
- should headcount filter be placed near the top or somewhere else

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast
https://github.com/user-attachments/assets/c0fa3d6d-0c6e-43b6-8bb0-29decff3ba75

