### PR TITLE
Event edit bug fix

### DIFF
--- a/src/app/components/StandaloneExpandedViewComponent.tsx
+++ b/src/app/components/StandaloneExpandedViewComponent.tsx
@@ -365,7 +365,7 @@ function ExpandedViewComponent({
               display={'flex'}
               flexDirection={['column', 'column', 'row']}
               justifyContent={
-                visitorData.role === 'admin'
+                visitorData.role === 'admin' || visitorData.role === 'super-admin'
                   ? 'space-around'
                   : ['center', 'center', 'end']
               }
@@ -373,7 +373,7 @@ function ExpandedViewComponent({
             >
               {signedIn ? (
                 <>
-                  {visitorData.role === 'admin' && (
+                  {(visitorData.role === 'admin' || visitorData.role === 'super-admin')&& (
                     <Link href={`/admin/events/edit/${editUrl}`}>
                       <Button
                         bg="#337774"

--- a/src/app/components/UserDashboard.tsx
+++ b/src/app/components/UserDashboard.tsx
@@ -745,6 +745,7 @@ const handleButtonClickToStopPropogation = (event: React.MouseEvent<HTMLButtonEl
      </div>
      <ExpandedViewComponent
         eventDetails={eventForExpandedViewComponent}
+        editUrl={eventForExpandedViewComponent?._id}
         showModal={isExpandedViewComponentOpen}
         setShowModal={toggleExpandedViewComponentOpen}
       />

--- a/src/app/components/calendar/Calendar.tsx
+++ b/src/app/components/calendar/Calendar.tsx
@@ -70,6 +70,7 @@ export default function Calendar(props: {
         />
         <ExpandedViewComponent
           eventDetails={getEvent}
+          editUrl={getEvent?._id}
           showModal={showExpandedView}
           setShowModal={setShowExpandedView}
         />


### PR DESCRIPTION
## Developer: Brady Welsh

Closes #297

### Pull Request Summary

- The mentioned bugs on the issue have been fixed
- Super admins are now able to view the edit event button
- Calendar links to edit event page have been fixed
- UserDashboard link to edit event page has been fixed

### Modifications

- StandaloneExpandedViewComponent.tsx - or statement added to check if the user is a super admin (so they can view the edit event button if they are a super admin)
- components/calendar/Calendar.tsx - modified to pass in the eventId into the StandaloneExpandedViewComponent (the event card)
- components/UserDashboard.tsx - modified to pass in eventId into the StandaloneExpandedViewComponent (the event card)

### Testing Considerations

- I used ctrl-shift-f to check all references to StandaloneExpandedViewComponent and I made sure all of them now pass in the event Id (which means they will link correctly)
- I also tested the edit event button on the Calendar page and it works now
- As a super admin I am able to view the Edit Event button for an event