### PR TITLE
feat: limit number of logs shown at a time

### DIFF
--- a/src/app/admin/audit/page.tsx
+++ b/src/app/admin/audit/page.tsx
@@ -13,6 +13,8 @@ const AuditPage = () => {
   const [userFilter, setUserFilter] = useState('');
   const [actionFilter, setActionFilter] = useState('');
   const [mounted, setMounted] = useState(false); // Helps prevent flickering on initial load
+  const [page, setPage] = useState(0);
+  const logLimit = 25;
 
   const fetchLogs = async () => {
     const res = await fetch('/api/logs', { cache: 'no-store' });
@@ -25,6 +27,7 @@ const AuditPage = () => {
     const fetchedlogs = await res.json();
     console.log("Fetching logs on client.")
     setLogs(fetchedlogs);
+    setPage(0);
     setIsLoading(false);
   };
 
@@ -97,7 +100,32 @@ const AuditPage = () => {
           ) : filteredLogs?.length === 0 ? (
             <Text>No logs found</Text>
           ) : (
-            filteredLogs?.map((log) => <MessageLog key={log._id} log={log} />)
+            <>
+              {filteredLogs?.slice(page * logLimit, (page+1) * logLimit).map(
+                (log) => <MessageLog key={log._id} log={log} />)}
+              {<div className={style.pageCountContainer}>
+                <Button 
+                  className={style.pageButton}
+                  isDisabled={page === 0}
+                  onClick={() => setPage(page-1)}>
+                    Previous
+                </Button>
+                <Text
+                  fontSize={['xl', 'xl', '2xl']}
+                  fontWeight="light"
+                  color="black"
+                >
+                  Page {page+1}
+                </Text>
+                <Button
+                  className={style.pageButton}
+                  isDisabled={(page+1) * logLimit >= filteredLogs.length} 
+                  onClick={() => setPage(page+1)}>
+                    Next
+                </Button>
+              </div>
+              }
+            </>
           )}
         </div>
       </main>

--- a/src/app/styles/admin/audit.module.css
+++ b/src/app/styles/admin/audit.module.css
@@ -58,3 +58,16 @@
   margin: 10px;
   border: 1px solid grey;
 }
+
+.pageCountContainer {
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  gap: 32px;
+  padding: 32px;
+}
+
+.pageButton {
+  width: 100px;
+}


### PR DESCRIPTION
limits logs to 25 per page (can be changed by modifying the logLimit value)

## Developer: Vinpatrik Magdangal

Closes #302 

### Pull Request Summary

This PR limits logs to only show 25 logs at a time. At the bottom of the page are a previous and next button that change the page. It also shows which page you are on. When clicking the refresh logs button, it also resets the page to the first page. Previous button gets disabled if the user is on the first page. Next button gets disabled when reaching the end of the logs.

### Modifications

[MODIFIED] src/app/admin/audit/page.tsx
- now slices filtered logs to get specified number of logs on a certain page
- number of logs per page can be changed by modifying the logLimit variable
- two buttons for previous and next page added to the bottom of list of logs

[MODIFIED] src/app/styles/admin/audit.module.css
- .pageButton and .pageCountContainer classes created
- container is centered and padded
- buttons just have a 100px width to make them look uniform

### Testing Considerations

Test that the correct number of logs appear and it doesn't look weird.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

![image](https://github.com/user-attachments/assets/b70f5189-5a9b-4a6d-9cd3-50142e538023)
![image](https://github.com/user-attachments/assets/c52b5f92-4e94-4aad-9954-1eeb73771b12)
