### PR TITLE
feat: limit number of users shown on user list

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -84,6 +84,8 @@ const UserList = () => {
   });
   const [loading, setLoading] = useState(true);
   const tableSize = useBreakpointValue({ base: "sm", md: "md" });
+  const [page, setPage] = useState(0);
+  const userLimit = 15;
 
   // calculate hours for each event in user schema
   const calculateTotalHours = (events: AttendedEventInfo[]): number => {
@@ -338,7 +340,7 @@ const UserList = () => {
                     </Td>
                     </Tr>
                 ) : (
-                    filteredUsers.map((user) => (
+                    filteredUsers.slice(page * userLimit, (page+1) * userLimit).map((user) => (
                     
                     <Tr key={user._id}>
                         <Td>{`${user.firstName} ${user.lastName}`}</Td>
@@ -355,6 +357,27 @@ const UserList = () => {
               </Tbody>
             </Table>
           </Box>
+          <div className={style.pageCountContainer}>
+            <Button 
+              className={style.pageButton}
+              isDisabled={page === 0}
+              onClick={() => setPage(page-1)}>
+                Previous
+            </Button>
+            <Text
+              fontSize={['xl', 'xl', '2xl']}
+              fontWeight="light"
+              color="black"
+            >
+              Page {page+1}
+            </Text>
+            <Button
+              className={style.pageButton}
+              isDisabled={(page+1) * userLimit >= filteredUsers.length} 
+              onClick={() => setPage(page+1)}>
+                Next
+            </Button>
+          </div>
       </div>
     </div>
   );

--- a/src/app/styles/admin/users.module.css
+++ b/src/app/styles/admin/users.module.css
@@ -78,6 +78,19 @@
     padding: 25px;
 }
 
+.pageCountContainer {
+    justify-content: center;
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    gap: 32px;
+    padding: 32px;
+}
+
+.pageButton {
+    width: 100px;
+}
+
 @media (max-width: 1000px) {
     .buttonContainer {
         align-items: center;


### PR DESCRIPTION
pretty much the same as the one in the audit log

## Developer: Vinpatrik Magdangal

Closes #303 

### Pull Request Summary

This PR is identical to the PR for #302, but is for the users table. The limit of users shown in the table is set to 15, but can be changed by modifying the userLimit variable. None of the previous functionality has been altered in any way. The next and previous buttons are disabled if using them would put them past the range that contains any users. Export to CSV still works as normal and returns every single user.

### Modifications

[MODIFIED] src/app/admin/users/page.tsx
- Limits the number of users shown by slicing the filteredUsers and only showing a section at a time
- Added a new userLimit variable that determines how many users are shown at a time
- Added two buttons at the bottom of the table that increment or decrement the current page

[MODIFIED] src/app/styles/admin/users.module.css
- I added the same styles as I did in #302
- Adds 2 classes to style the next/previous buttons and the container that holds them

### Testing Considerations

Change up the limit and make sure it still works. If you need any visual improvements, we can do that in both this PR and #302 if you'd like.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

![image](https://github.com/user-attachments/assets/3de680b0-5d6c-4813-ae7c-aaa3cc53b1ee)
![image](https://github.com/user-attachments/assets/2d8a6307-47d2-40ba-b7da-9e3bf9f0ff11)

