### PR TITLE
311 using rich text for event description

### DIFF
--- a/src/app/components/EditEvent.tsx
+++ b/src/app/components/EditEvent.tsx
@@ -36,6 +36,7 @@ import { CreateTemporaryGroup } from "./ViewGroups";
 import "../fonts/fonts.css";
 import { useRef } from "react";
 import { CheckIcon, EditIcon, AddIcon } from "@chakra-ui/icons";
+import MDEditor from "@uiw/react-md-editor";
 
 const EditEvent = ({
   event,
@@ -94,7 +95,7 @@ const EditEvent = ({
   const handleDateChange = (e: any) => setDate(e.target.value);
   const handleStartChange = (e: any) => setStart(e.target.value);
   const handleEndChange = (e: any) => setEnd(e.target.value);
-  const handleDescChange = (e: any) => setDesc(e.target.value);
+  const handleDescChange = (e: any) => setDesc(e);
 
   const handleVolChange = () => {
     setVol(!vol);
@@ -437,10 +438,10 @@ const EditEvent = ({
                   <FormLabel color="black" fontWeight="bold">
                     Event Description
                   </FormLabel>
-                  <Textarea
-                    placeholder="Event Description"
+                  <MDEditor
                     value={desc}
-                    onChange={handleDescChange}
+                    onChange={(e) => handleDescChange(e)}
+                    data-color-mode="light"
                   />
                 </FormControl>
               </Stack>

--- a/src/app/components/EditEventPrimaryInfo.tsx
+++ b/src/app/components/EditEventPrimaryInfo.tsx
@@ -6,6 +6,7 @@ import EditEvent from '@components/EditEvent';
 import editButton from '/docs/images/edit_details.svg'
 import { useEventId } from 'app/lib/swrfunctions';
 import { IGroup } from 'database/groupSchema';
+import MarkdownPreview from '@uiw/react-markdown-preview';
 
 const EditEventPrimaryInfo = ({ eventId }: { eventId: string }) => {
     const [loading, setLoading] = useState(true);
@@ -105,7 +106,13 @@ const EditEventPrimaryInfo = ({ eventId }: { eventId: string }) => {
                             <Text className={styles.eventField}>Disability Accommodations</Text>
                             <Text className={styles.eventEntry}>{eventData.wheelchairAccessible ? 'Wheelchair Accessible' : 'None'}</Text>
                             <Text className={styles.eventField}>Description</Text>
-                            <Text className={styles.eventEntry}>{eventData.description}</Text>
+                            <Text className={styles.eventEntry}>
+                                <MarkdownPreview 
+                                    source={eventData.description}
+                                    wrapperElement={{'data-color-mode': 'light'}}
+                                >
+                                </MarkdownPreview>
+                            </Text>
                         </Box>
                     </>
                 )}

--- a/src/app/components/EditEventPrimaryInfo.tsx
+++ b/src/app/components/EditEventPrimaryInfo.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { Box, Text, Image, Spinner, UnorderedList, ListItem } from '@chakra-ui/react';
+import { Box, Text, Image, Spinner, UnorderedList, ListItem, background } from '@chakra-ui/react';
 import React, { useState, useEffect } from 'react'
 import styles from "../styles/admin/editEvent.module.css";
 import EditEvent from '@components/EditEvent';
@@ -101,18 +101,17 @@ const EditEventPrimaryInfo = ({ eventId }: { eventId: string }) => {
                             )}
                             <Text className={styles.eventField}>Volunteer Event</Text>
                             <Text className={styles.eventEntry}>{eventData.volunteerEvent ? "Yes, counts for volunteer hours" : "No"}</Text>
-                            <Text className={styles.eventField}>Languages</Text>
-                            <Text className={styles.eventEntry}>{eventData.spanishSpeakingAccommodation ? 'English, Spanish' : 'English'}</Text>
+                            <Text className={styles.eventField}>Event Language</Text>
+                            <Text className={styles.eventEntry}>{eventData.spanishSpeakingAccommodation ? 'Spanish' : 'English'}</Text>
                             <Text className={styles.eventField}>Disability Accommodations</Text>
                             <Text className={styles.eventEntry}>{eventData.wheelchairAccessible ? 'Wheelchair Accessible' : 'None'}</Text>
                             <Text className={styles.eventField}>Description</Text>
-                            <Text className={styles.eventEntry}>
-                                <MarkdownPreview 
-                                    source={eventData.description}
-                                    wrapperElement={{'data-color-mode': 'light'}}
-                                >
-                                </MarkdownPreview>
-                            </Text>
+                            <MarkdownPreview 
+                                className={styles.eventEntry}
+                                style={{ backgroundColor:'#fbf9f9' }}
+                                source={eventData.description}
+                                wrapperElement={{'data-color-mode': 'light'}}
+                            />
                         </Box>
                     </>
                 )}


### PR DESCRIPTION
## Developer: Vinpatrik Magdangal

Closes #311 

### Pull Request Summary

Updates Edit Event form to have a rich text editor. The edit event preview also uses a rich text preview rather than Text.
However, I could not separate the preview from the editor, so it unfortunately is squished. I also do not know how to change the background color of MarkdownPreview to match the box. background-color does not do it.

### Modifications

src/app/components/EditEvent.tsx
- Import MDEditor, replaced Textarea with MDEditor. Also changed handleDescChange to work properly with MDEditor

src/app/components/EditEventPrimaryInfo.tsx
- Added MarkdownPreview to this page to show rich text instead of a Text element for description.

### Testing Considerations

Modify some descriptions and make sure everything shows rich text. The popup already works, but I've checked that the edit event page works too.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

Edit Form:
![image](https://github.com/user-attachments/assets/60608143-4111-40be-bf00-02eeab877af3)

Description in Admin Event Details:
![image](https://github.com/user-attachments/assets/0ab0ff66-c153-489c-aafa-aab4594127da)

How the popup looks (just for comparison since it already works here)
![image](https://github.com/user-attachments/assets/71c7d828-2652-4d22-b193-0c45958e0644)


