### PR TITLE
308 updates to wording around accessibility

### DIFF
--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -276,13 +276,6 @@ const EventPreview = () => {
           <CheckboxGroup colorScheme="green" defaultValue={[]}>
             <Stack spacing={[1, 5]} direction={["column", "column"]} ml="1.5">
               <Checkbox
-                value="spanish"
-                colorScheme="blue"
-                onChange={() => setSpanishSpeakingOnly(!spanishSpeakingOnly)}
-              >
-                <div className={style.checkboxLabel}>Spanish Speaking</div>
-              </Checkbox>
-              <Checkbox
                 value="wheelchair accessible"
                 colorScheme="blue"
                 onChange={() => setWheelchairAccessible(!wheelchairAccessible)}
@@ -295,6 +288,20 @@ const EventPreview = () => {
                 onChange={() => setGroupOnly(!groupOnly)}
               >
                 <div className={style.checkboxLabel}>Group Only</div>
+              </Checkbox>
+            </Stack>
+          </CheckboxGroup>
+        </div>
+        <div className={style.filterContainer}>
+          <div className={style.filterHeader}>Languages</div>
+          <CheckboxGroup colorScheme="green" defaultValue={[]}>
+            <Stack spacing={[1, 5]} direction={["column", "column"]} ml="1.5">
+              <Checkbox
+                value="spanish"
+                colorScheme="blue"
+                onChange={() => setSpanishSpeakingOnly(!spanishSpeakingOnly)}
+              >
+                <div className={style.checkboxLabel}>Spanish</div>
               </Checkbox>
             </Stack>
           </CheckboxGroup>

--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -32,7 +32,8 @@ const EventPreview = () => {
     value: "earliest",
     label: "From Earliest",
   });
-  const [spanishSpeakingOnly, setSpanishSpeakingOnly] = useState(false);
+  const [spanishSpeakingEvent, setspanishSpeakingEvent] = useState(true);
+  const [englishSpeakingEvent, setenglishSpeakingEvent] = useState(true);
   const [wheelchairAccessible, setWheelchairAccessible] = useState(false);
   const [groupOnly, setGroupOnly] = useState(false);
   const [showPastEvents, setShowPastEvents] = useState(false);
@@ -118,7 +119,8 @@ const EventPreview = () => {
   const filteredEvents =
     events
       ?.filter((event) =>
-        spanishSpeakingOnly ? event.spanishSpeakingAccommodation : true
+        (spanishSpeakingEvent && event.spanishSpeakingAccommodation) ||
+        (englishSpeakingEvent && !event.spanishSpeakingAccommodation)
       )
       .filter((event) =>
         wheelchairAccessible ? event.wheelchairAccessible : true
@@ -271,8 +273,29 @@ const EventPreview = () => {
             </Stack>
           </CheckboxGroup>
         </div>
-        <div className={style.filterContainerTypeAccessibility}>
-          <div className={style.filterHeader}>Accessibility</div>
+        <div className={style.filterContainer}>
+          <div className={style.filterHeader}>Event Language</div>
+            <CheckboxGroup colorScheme="green">
+            <Stack spacing={[1, 5]} direction={["column", "column"]} ml="1.5">
+              <Checkbox
+              isChecked={spanishSpeakingEvent}
+              colorScheme="blue"
+              onChange={() => setspanishSpeakingEvent(!spanishSpeakingEvent)}
+              >
+              <div className={style.checkboxLabel}>Spanish</div>
+              </Checkbox>
+              <Checkbox
+              isChecked={englishSpeakingEvent}
+              colorScheme="blue"
+              onChange={() => setenglishSpeakingEvent(!englishSpeakingEvent)}
+              >
+              <div className={style.checkboxLabel}>English</div>
+              </Checkbox>
+            </Stack>
+            </CheckboxGroup>
+        </div>
+        <div className={style.filterContainer}>
+          <div className={style.filterHeader}>Other Filters</div>
           <CheckboxGroup colorScheme="green" defaultValue={[]}>
             <Stack spacing={[1, 5]} direction={["column", "column"]} ml="1.5">
               <Checkbox
@@ -288,20 +311,6 @@ const EventPreview = () => {
                 onChange={() => setGroupOnly(!groupOnly)}
               >
                 <div className={style.checkboxLabel}>Group Only</div>
-              </Checkbox>
-            </Stack>
-          </CheckboxGroup>
-        </div>
-        <div className={style.filterContainer}>
-          <div className={style.filterHeader}>Languages</div>
-          <CheckboxGroup colorScheme="green" defaultValue={[]}>
-            <Stack spacing={[1, 5]} direction={["column", "column"]} ml="1.5">
-              <Checkbox
-                value="spanish"
-                colorScheme="blue"
-                onChange={() => setSpanishSpeakingOnly(!spanishSpeakingOnly)}
-              >
-                <div className={style.checkboxLabel}>Spanish</div>
               </Checkbox>
             </Stack>
           </CheckboxGroup>

--- a/src/app/components/CreateEvent.tsx
+++ b/src/app/components/CreateEvent.tsx
@@ -250,7 +250,7 @@ const CreateEvent = () => {
                 isChecked={span}
                 onChange={handleSpanChange}
               >
-                Spanish Speaking Accommodations
+                Spanish Speaking
               </Switch>
             </Stack>
           </ModalBody>

--- a/src/app/components/EditEvent.tsx
+++ b/src/app/components/EditEvent.tsx
@@ -636,7 +636,7 @@ const EditEvent = ({
                 isChecked={span}
                 onChange={handleSpanChange}
               >
-                Spanish Speaking Accommodations
+                Spanish Speaking
               </Switch>
             </Stack>
           </ModalBody>

--- a/src/app/components/EditEvent.tsx
+++ b/src/app/components/EditEvent.tsx
@@ -636,7 +636,7 @@ const EditEvent = ({
                 isChecked={span}
                 onChange={handleSpanChange}
               >
-                Spanish Speaking
+                Event is in Spanish 
               </Switch>
             </Stack>
           </ModalBody>

--- a/src/app/components/EditEventPrimaryInfo.tsx
+++ b/src/app/components/EditEventPrimaryInfo.tsx
@@ -99,9 +99,9 @@ const EditEventPrimaryInfo = ({ eventId }: { eventId: string }) => {
                             <Text className={styles.eventEntry}>No items to bring</Text>
                             )}
                             <Text className={styles.eventField}>Volunteer Event</Text>
-                            <Text className={styles.eventEntry}>{eventData.volunteerEvent ? "Yes, counts for volunteer hours" : "No"}</Text>
-                            <Text className={styles.eventField}>Languages</Text>
-                            <Text className={styles.eventEntry}>{eventData.spanishSpeakingAccommodation ? 'English, Spanish' : 'English'}</Text>
+                            <Text className={styles.eventEntry}>{eventData.volunteerEvent ? "Yes, counts for volunteer hours" : "No, does not count for volunteer hours"}</Text>
+                            <Text className={styles.eventField}>Event Language</Text>
+                            <Text className={styles.eventEntry}>{eventData.spanishSpeakingAccommodation ? 'Spanish' : 'English'}</Text>
                             <Text className={styles.eventField}>Disability Accommodations</Text>
                             <Text className={styles.eventEntry}>{eventData.wheelchairAccessible ? 'Wheelchair Accessible' : 'None'}</Text>
                             <Text className={styles.eventField}>Description</Text>

--- a/src/app/components/StandaloneCreateEvent.tsx
+++ b/src/app/components/StandaloneCreateEvent.tsx
@@ -180,7 +180,7 @@ import {
     
                 <Switch fontWeight='bold' color='grey' isChecked={wc} onChange={handleWCChange}>Wheelchair Accessibility</Switch>
     
-                <Switch fontWeight='bold' color='grey' isChecked={span} onChange={handleSpanChange}>Spanish Speaking Accommodations</Switch>
+                <Switch fontWeight='bold' color='grey' isChecked={span} onChange={handleSpanChange}>Spanish Speaking</Switch>
   
               </Stack>
             </ModalBody>

--- a/src/app/components/StandaloneExpandedViewComponent.tsx
+++ b/src/app/components/StandaloneExpandedViewComponent.tsx
@@ -323,15 +323,9 @@ function ExpandedViewComponent({
                   )}
                   <Flex direction={'column'}>
                     <FormLabel color="black" fontWeight="bold" fontSize={'xl'}>
-                      Languages
+                      Event Language
                     </FormLabel>
-                    <Stack spacing={2}>
-                      <MarkdownPreview
-                        className={style.preview}
-                        style={{ fontWeight: 'light' }}
-                        source={'- English'}
-                        wrapperElement={{ 'data-color-mode': 'light' }}
-                      />
+                    <Stack spacing={2}>  
                       {eventDetails.spanishSpeakingAccommodation ? (
                         <MarkdownPreview
                           className={style.preview}
@@ -340,7 +334,12 @@ function ExpandedViewComponent({
                           wrapperElement={{ 'data-color-mode': 'light' }}
                         />
                       ) : (
-                        <></>
+                        <MarkdownPreview
+                        className={style.preview}
+                        style={{ fontWeight: 'light' }}
+                        source={'- English'}
+                        wrapperElement={{ 'data-color-mode': 'light' }}
+                        />
                       )}
                     </Stack>
                   </Flex>

--- a/src/app/components/StandaloneExpandedViewComponent.tsx
+++ b/src/app/components/StandaloneExpandedViewComponent.tsx
@@ -299,9 +299,8 @@ function ExpandedViewComponent({
                       )}
                     </Stack>
                   </Flex>
-                  {!eventDetails.spanishSpeakingAccommodation &&
-                  !eventDetails.wheelchairAccessible ? null : ( // If neither spanish speaking nor wheelchair accessible, return null
-                    <Stack spacing={2}>
+                  {eventDetails.wheelchairAccessible ? ( // If neither spanish speaking nor wheelchair accessible, return null
+                    <Flex direction={'column'}>
                       <FormLabel
                         color="black"
                         fontWeight="bold"
@@ -309,17 +308,15 @@ function ExpandedViewComponent({
                       >
                         Accommodations
                       </FormLabel>
-                      {eventDetails.wheelchairAccessible ? (
                         <MarkdownPreview
                           className={style.preview}
                           style={{ fontWeight: 'light' }}
                           source={'- Wheelchair Accessible'}
                           wrapperElement={{ 'data-color-mode': 'light' }}
                         />
-                      ) : (
-                        <></>
-                      )}
-                    </Stack>
+                    </Flex>
+                  ) : (
+                    <></>
                   )}
                   <Flex direction={'column'}>
                     <FormLabel color="black" fontWeight="bold" fontSize={'xl'}>
@@ -375,9 +372,8 @@ function ExpandedViewComponent({
                       )}
                     </Stack>
                   </Flex>
-                  {!eventDetails.spanishSpeakingAccommodation &&
-                  !eventDetails.wheelchairAccessible ? null : (
-                    <Stack spacing={2}>
+                  {eventDetails.wheelchairAccessible ? (
+                    <Stack>
                       <FormLabel
                         color="black"
                         fontWeight="bold"
@@ -385,28 +381,38 @@ function ExpandedViewComponent({
                       >
                         Accommodations
                       </FormLabel>
-                      {eventDetails.wheelchairAccessible ? (
                         <MarkdownPreview
                           className={style.preview}
                           style={{ fontWeight: 'light' }}
                           source={'- Wheelchair Accessible'}
                           wrapperElement={{ 'data-color-mode': 'light' }}
                         />
-                      ) : (
-                        <></>
-                      )}
+                    </Stack>
+                  ) : (
+                    <></>
+                  )}
+                  <Flex direction={'column'}>
+                    <FormLabel color="black" fontWeight="bold" fontSize={'xl'}>
+                      Event Language
+                    </FormLabel>
+                    <Stack spacing={2}>  
                       {eventDetails.spanishSpeakingAccommodation ? (
                         <MarkdownPreview
                           className={style.preview}
                           style={{ fontWeight: 'light' }}
-                          source={'- Spanish-Speaking'}
+                          source={'- Spanish'}
                           wrapperElement={{ 'data-color-mode': 'light' }}
                         />
                       ) : (
-                        <></>
+                        <MarkdownPreview
+                        className={style.preview}
+                        style={{ fontWeight: 'light' }}
+                        source={'- English'}
+                        wrapperElement={{ 'data-color-mode': 'light' }}
+                        />
                       )}
                     </Stack>
-                  )}
+                  </Flex>
                 </Flex>
               )}
             </Stack>

--- a/src/app/components/StandaloneExpandedViewComponent.tsx
+++ b/src/app/components/StandaloneExpandedViewComponent.tsx
@@ -319,18 +319,31 @@ function ExpandedViewComponent({
                       ) : (
                         <></>
                       )}
+                    </Stack>
+                  )}
+                  <Flex direction={'column'}>
+                    <FormLabel color="black" fontWeight="bold" fontSize={'xl'}>
+                      Languages
+                    </FormLabel>
+                    <Stack spacing={2}>
+                      <MarkdownPreview
+                        className={style.preview}
+                        style={{ fontWeight: 'light' }}
+                        source={'- English'}
+                        wrapperElement={{ 'data-color-mode': 'light' }}
+                      />
                       {eventDetails.spanishSpeakingAccommodation ? (
                         <MarkdownPreview
                           className={style.preview}
                           style={{ fontWeight: 'light' }}
-                          source={'- Spanish-Speaking'}
+                          source={'- Spanish'}
                           wrapperElement={{ 'data-color-mode': 'light' }}
                         />
                       ) : (
                         <></>
                       )}
                     </Stack>
-                  )}
+                  </Flex>
                 </Flex>
               ) : (
                 <Flex direction={'column'} ml={'5%'} mb={'10%'} gap={4}>

--- a/src/app/styles/admin/events.module.css
+++ b/src/app/styles/admin/events.module.css
@@ -7,7 +7,7 @@
 .sidebar {
   display: flex;
   flex-direction: column;
-  gap: 25px;
+  gap: 10px;
   width: 15vw;
 }
 
@@ -77,11 +77,6 @@
   margin-top: 20px;
 }
 
-.filterContainer {
-  margin-top: 20px;
-  margin-bottom: 20px;
-  margin-left: 0px;
-}
 .filterHeader {
   margin-left: 0px;
   font-size: 16px;
@@ -177,14 +172,7 @@
     padding-bottom: 40px;
   }
 
-  .filterContainerTypeAccessibility {
-    flex-direction: column;
-    display: flex;
-    gap: 20px;
-  }
-
-  .filterContainer,
-  .filterContainerTypeAccessibility {
+  .filterContainer{
     margin-top: 0px;
     width: 100%;
     align-items: flex-start;


### PR DESCRIPTION
not an accessibility option anymore

## Developer: Vinpatrik Magdangal

Closes #308 

### Pull Request Summary

Reformats some of the accessibility options by having language be its own thing. 

### Modifications

src/app/admin/events/page.tsx
- Took out the spanish filter out of accessibility and made a new languages section

src/app/components/StandaloneExpandedViewComponent.tsx
- Set up a new Flex and Stack to have a new column under each event listing languages
- English is always going to be in languages, but will show spanish if that option for the event was selected

src/app/components/CreateEvent.tsx
src/app/components/EditEvent.tsx
src/app/components/StandaloneCreateEvent.tsx
- Removed instances of spanish being an accommodation

### Testing Considerations

Make sure there are no other instances where the Spanish language is considered an accommodation

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

Language Filter
![image](https://github.com/user-attachments/assets/87032e1a-5337-402d-a657-374a8a467e86)

Event w/ Spanish
![image](https://github.com/user-attachments/assets/c951663d-e786-4336-a0fc-d18f68b7399c)

Event w/o Spanish
![image](https://github.com/user-attachments/assets/36c01b0e-b1a5-4392-ad94-f5c695cc2c89)

Event Editing/Creating
![image](https://github.com/user-attachments/assets/ecaff25f-9d2a-40a1-97cc-d4daaa00b2be)
