### PR TITLE
316 Update the Audit Log Comp to Not Have a Arrow Link for Delete Actions

### DIFF
--- a/src/app/components/MessageLog.tsx
+++ b/src/app/components/MessageLog.tsx
@@ -63,8 +63,6 @@ useEffect(() => {
     // Renders a card with the log information
     <Card
       className={style.auditPreview}
-      role="button"
-      onClick={handleClick}
       borderRadius="lg"
       borderWidth="1px"
       borderColor="gray.400"
@@ -77,7 +75,11 @@ useEffect(() => {
           </Heading>
           <Text>{formattedDate}</Text>
         </div>
-        <RiArrowRightSLine className={style.auditIcon} />
+        {(log.action).includes("deleted") ? null : (
+          <RiArrowRightSLine className={style.auditIcon}
+          role="button"
+          onClick={handleClick} />
+        )}
       </CardBody>
     </Card>
   );


### PR DESCRIPTION
## Developer: Vinpatrik Magdangal

Closes #316 

### Pull Request Summary

Super small change. Removed the arrow links in logs that deleted users, events, and groups.
The entire audit log also acted like a button rather than just the arrow, so now only the arrow has that feature.

### Modifications

src/app/components/MessageLog.tsx
- If (log.action).includes("deleted"), the button will not appear.
- The button also has the button role and onClick now. Since the arrow does this now, there's nothing in the "delete" logs to click.

### Testing Considerations

Make sure this only happens in "delete" logs, and that those "delete" logs also don't have any arrows.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

Account deletion
![image](https://github.com/user-attachments/assets/3cc11eb9-6e51-4f46-993b-c3aae58ca51c)

Event and group deletion
![image](https://github.com/user-attachments/assets/2a399fae-1df4-4aa1-932b-ce4780cb60f9)
