### PR TITLE
320 volunteer log counts events using volunteerEvent instead of eventType

### DIFF
--- a/src/app/admin/hours/page.tsx
+++ b/src/app/admin/hours/page.tsx
@@ -20,7 +20,7 @@ import Link from 'next/link';
 import { useUser } from '@clerk/clerk-react';
 import { IEvent } from '../../../database/eventSchema';
 import { formatDate, formatDuration, timeOfDay } from '../../lib/dates';
-import { eventHours, filterPastEvents, filterEventsByType } from '../../lib/hours';
+import { eventHours, filterPastEvents, filterEventsByType, filterVolunteerEvents } from '../../lib/hours';
 import { getUserDbData } from 'app/lib/authentication';
 import { IUser } from '@database/userSchema';
 import "../../fonts/fonts.css"
@@ -75,7 +75,7 @@ const AttendedEvents = () => {
       throw new Error(`Failed to fetch events: ${eventsResponse.statusText}`);
     }
     const allEvents: IEvent[] = await eventsResponse.json();
-    const volunteerEvents = filterEventsByType(allEvents, "Volunteer");
+    const volunteerEvents = filterVolunteerEvents(allEvents);
     const csvData = volunteerEvents.map((event: IEvent) => ({
       eventName: event.eventName,
       eventDate: formatDate(event.startTime),

--- a/src/app/lib/hours.tsx
+++ b/src/app/lib/hours.tsx
@@ -166,3 +166,9 @@ export function filterEventsByType(
 ){
   return events.filter(event => event.eventType?.toLowerCase() === eventType.toLowerCase());
 }
+
+export function filterVolunteerEvents(
+  events: IEvent[]
+){
+  return events.filter(event => event.volunteerEvent);
+}


### PR DESCRIPTION
## Developer: Vinpatrik Magdangal

Closes #320 

### Pull Request Summary

Incredibly small change. The volunteer log now gets events where volunteerEvent is true rather than if eventType is "Volunteer".
volunteerEvent is already in the event schema.

### Modifications

src/app/admin/hours/page.tsx
- replaces filterEventsByType to use filterVolunteerEvents instead

src/app/lib/hours.tsx
- new function filterVolunteerEvents that will return events that have volunteerEvent as true

### Testing Considerations

Check that valid events are in the log now.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

![image](https://github.com/user-attachments/assets/28b04690-9b3d-4e87-b42f-3965d2262f80)
