### PR TITLE
fix: added Groups Only description to edit event page

### DIFF
--- a/src/app/components/EditEventPrimaryInfo.tsx
+++ b/src/app/components/EditEventPrimaryInfo.tsx
@@ -101,6 +101,8 @@ const EditEventPrimaryInfo = ({ eventId }: { eventId: string }) => {
                             )}
                             <Text className={styles.eventField}>Volunteer Event</Text>
                             <Text className={styles.eventEntry}>{eventData.volunteerEvent ? "Yes, counts for volunteer hours" : "No, does not count for volunteer hours"}</Text>
+                            <Text className={styles.eventField}>Group Only</Text>
+                            <Text className={styles.eventEntry}>{eventData.groupsOnly ? "Yes, only the selected groups can participate" : "No, anyone can participate"}</Text>
                             <Text className={styles.eventField}>Event Language</Text>
                             <Text className={styles.eventEntry}>{eventData.spanishSpeakingAccommodation ? 'Spanish' : 'English'}</Text>
                             <Text className={styles.eventField}>Disability Accommodations</Text>


### PR DESCRIPTION
## Developer: Brady Welsh

Closes #332 

### Pull Request Summary

- Edit Event page now shows the groups only 
- I noticed that there was a switch when you edit the event for the groups only, which went against the issue description, so I didn't make any changes to that part (I tested this switch and it worked)

### Modifications

- components/EditEventPrimaryInfo.tsx - added a Text element that displays differing messages depending on if the event is for groups only or not

### Testing Considerations

- I tested to make sure the box shows up and the switch works
- I'm not sure if the text I chose was perfect but that's easy to adjust


### Screenshots/Screencast

![image](https://github.com/user-attachments/assets/d3d11c01-d295-43df-ba6d-74ad33fd5f38)
![image](https://github.com/user-attachments/assets/7acb4338-14aa-49b3-b138-8656899162e0)

