### PR TITLE
334 fix screen size formatting for audit log

### DIFF
--- a/src/app/admin/audit/page.tsx
+++ b/src/app/admin/audit/page.tsx
@@ -70,20 +70,22 @@ const AuditPage = () => {
             >
               Filter:
             </Text>
-            <Input
-              placeholder="Filter by user"
-              value={userFilter}
-              onChange={(e) => setUserFilter(e.target.value)}
-              width="200px"
-              ml={4}
-            />
-            <Input
-              placeholder="Filter by action"
-              value={actionFilter}
-              onChange={(e) => setActionFilter(e.target.value)}
-              width="200px"
-              ml={4}
-            />
+            <div className={style.filterButtons}>
+              <Input
+                placeholder="Filter by user"
+                value={userFilter}
+                onChange={(e) => setUserFilter(e.target.value)}
+                width="200px"
+                ml={4}
+              />
+              <Input
+                placeholder="Filter by action"
+                value={actionFilter}
+                onChange={(e) => setActionFilter(e.target.value)}
+                width="200px"
+                ml={4}
+              />
+            </div>
             <Button onClick={fetchLogs} ml={4}>
               Refresh Logs
             </Button>

--- a/src/app/styles/admin/audit.module.css
+++ b/src/app/styles/admin/audit.module.css
@@ -19,6 +19,11 @@
   gap: 36px;
 }
 
+.filterButtons {
+  display: flex;
+  flex-direction: row;
+}
+
 .auditPreview {
   width: 100%;
   margin: auto;
@@ -70,4 +75,17 @@
 
 .pageButton {
   width: 100px;
+}
+
+@media (max-width: 1050px) {
+  .auditPage {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 850px) {
+  .filtering {
+    flex-direction: column;
+    gap: 10px;
+  }
 }


### PR DESCRIPTION
## Developer: Vinpatrik Magdangal

Closes #334 

### Pull Request Summary

Stacks the buttons on top of each other based on the size of the screen. At 1050px, when the navbar goes to mobile view, The "filter" text will appear on top of the options. At 850px, the buttons will stack on top of each other so filters can always be used. I decided to have the 1050px version so there isn't so much white space.

### Modifications

src/app/admin/audit/page.tsx
- Created a new div with class 'filterButtons' so that buttons wil still be next to each other when the options are stacked as a column

src/app/styles/admin/audit.module.css
- At 1050px, the 'Audit Log' text will sit above the filter options
- At 850px, all options will stack as a column, aside from filter input boxes

### Testing Considerations

Verify that it looks good. It still functions as normal since only the styles were changed.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

@ 1050px to 851px
![image](https://github.com/user-attachments/assets/1dc8a645-d8a4-483a-a5ad-1cf1214a4e4d)

@ 850px and less
![image](https://github.com/user-attachments/assets/159f168e-36b5-407f-b689-a425bc153d29)

