### PR TITLE
335 waiver titles show date instead of version

### DIFF
--- a/src/app/admin/waivers/page.tsx
+++ b/src/app/admin/waivers/page.tsx
@@ -170,6 +170,11 @@ export default function WaiverVersions() {
     setIsDeleteDialogOpen(true);
   };
 
+  const getWaiverName = (version: IWaiverVersion) => {
+    const waiverDate = new Date(version.dateCreated);
+    return `Waiver ${waiverDate.getMonth()}/${waiverDate.getDate()}/${waiverDate.getFullYear()%100}`;
+  };  
+
   const handleDelete = async () => {
     if (!waiverToDelete) return;
 
@@ -256,7 +261,7 @@ export default function WaiverVersions() {
           <Flex width="full" justify="space-between" alignItems="flex-start">
             <Box
               width="30%"
-              maxWidth="250px"
+              maxWidth="300px"
               p={[5, 5, 5, 5]}
               bg="#F5F5F5"
               borderTopLeftRadius="md"
@@ -297,7 +302,7 @@ export default function WaiverVersions() {
                       justifyContent="flex-start"
                       onClick={() => handleVersionSelect(version)}
                     >
-                      Waiver v{version.version} {version.isActiveWaiver ? "(Active)" : ""}
+                      {getWaiverName(version)} {version.isActiveWaiver ? "(Active)" : ""}
                     </Button>
                     <IconButton
                       size="xs"
@@ -423,7 +428,7 @@ export default function WaiverVersions() {
                         justifyContent="flex-start"
                         onClick={() => handleVersionSelect(version)}
                       >
-                        Waiver v{version.version} {version.isActiveWaiver ? "(Active)" : ""}
+                        {getWaiverName(version)} {version.isActiveWaiver ? "(Active)" : ""}
                       </Button>
                       <IconButton
                         size="xs"
@@ -572,7 +577,7 @@ export default function WaiverVersions() {
             </AlertDialogHeader>
 
             <AlertDialogBody>
-              Are you sure you want to delete Waiver v{waiverToDelete?.version}?
+              Are you sure you want to delete {waiverToDelete?.version && getWaiverName(waiverToDelete)}?
               This action cannot be undone.
             </AlertDialogBody>
 

--- a/src/app/admin/waivers/page.tsx
+++ b/src/app/admin/waivers/page.tsx
@@ -403,7 +403,7 @@ export default function WaiverVersions() {
             >
               View Waiver Versions
             </Button>
-            <Drawer isOpen={isOpen} placement="left" onClose={onClose}>
+            <Drawer isOpen={isOpen} placement="left" onClose={onClose} size="sm">
               <DrawerOverlay />
               <DrawerContent>
                 <DrawerCloseButton />
@@ -415,6 +415,7 @@ export default function WaiverVersions() {
                       key={version._id}
                       align="center"
                       gap={2}
+                      width="375px"
                       _hover={{ "& .delete-icon": { opacity: 1 } }}
                     >
                       <Button

--- a/src/app/admin/waivers/page.tsx
+++ b/src/app/admin/waivers/page.tsx
@@ -95,7 +95,7 @@ export default function WaiverVersions() {
 
   const handleUpdateWaiver = async () => {
     if (!selectedVersion) return;
-
+    console.log(selectedVersion.dateCreated);
     try {
       console.log("Updating waiver with data:", {
         body: waiverContent,
@@ -172,7 +172,7 @@ export default function WaiverVersions() {
 
   const getWaiverName = (version: IWaiverVersion) => {
     const waiverDate = new Date(version.dateCreated);
-    return `Waiver ${waiverDate.getMonth()}/${waiverDate.getDate()}/${waiverDate.getFullYear()%100}`;
+    return `Waiver ${waiverDate.getMonth()+1}/${waiverDate.getDate()}/${waiverDate.getFullYear()%100} - ${waiverDate.getHours()}:${waiverDate.getMinutes()}:${waiverDate.getSeconds()}`;
   };  
 
   const handleDelete = async () => {
@@ -260,8 +260,8 @@ export default function WaiverVersions() {
           // Hardcoded Sidebar for Larger Screens
           <Flex width="full" justify="space-between" alignItems="flex-start">
             <Box
-              width="30%"
-              maxWidth="300px"
+              width="40%"
+              maxWidth="375px"
               p={[5, 5, 5, 5]}
               bg="#F5F5F5"
               borderTopLeftRadius="md"


### PR DESCRIPTION
## Developer: Vinpatrik Magdangal

Closes #335 

### Pull Request Summary

Waivers in waiver page show date instead of a version number. It shows it in format MM/DD/YY.

### Modifications

src/app/admin/waivers/page.tsx
- New function that returns "Waiver MM/DD/YY"
- Waivers show new waiver name instead of Waiver v#
- Shows new name in delete popup and waiver views (both screen sizes)

### Testing Considerations

Verify that everywhere shows the new Waiver MM/DD/YY format.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast
Large view
![image](https://github.com/user-attachments/assets/7514c725-19ba-4799-bf7b-c2275c89a698)

Small view
![image](https://github.com/user-attachments/assets/e6f72279-94f9-43d4-a5f5-9b8736380ba0)

Delete popup
![image](https://github.com/user-attachments/assets/db317f0e-c388-4671-b83e-f7f757751ac1)