### PR TITLE
299 set the default beaver image as the backup for deleted images

### DIFF
--- a/src/app/components/ChakraNextImage.tsx
+++ b/src/app/components/ChakraNextImage.tsx
@@ -1,7 +1,28 @@
 // Image.js
 import { chakra } from "@chakra-ui/react";
 import Image from "next/image";
+import React, { useState } from 'react';
 
-export default chakra(Image, {
-  shouldForwardProp: (prop) => ["src", "alt", "objectFit","layout"].includes(prop),
-});
+const EnhancedChakraNextImage = (props: any) => {
+  const [imageSrc, setImageSrc] = useState(props.src);
+
+  const handleImageError = () => {
+    setImageSrc('/beaver-eventcard.jpeg');
+  };
+
+  return (
+    <chakra.img
+      {...props}
+      src={imageSrc}
+      onError={handleImageError}
+      style={{
+        objectFit: 'cover',
+        width: '100%',
+        height: '100%',
+        borderRadius: 'inherit',
+      }}
+    />
+  );
+};
+
+export default EnhancedChakraNextImage;

--- a/src/app/components/EventCard.tsx
+++ b/src/app/components/EventCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Image from 'next/image';
 import style from '@styles/admin/eventCard.module.css';
 import { IEvent } from '@database/eventSchema';
@@ -40,6 +40,19 @@ const EventCard: React.FC<EventPreviewProps> = ({
   groupName,
   onClick,
 }) => {
+  const isValidUrl = (url: string | null): boolean => {
+    if (!url) return false;
+    try {
+      new URL(url);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const initialImage = isValidUrl(event.eventImage) ? event.eventImage! : '/beaver-eventcard.jpeg';
+  const [imageSrc, setImageSrc] = useState<string>(initialImage);
+
   const formatDate = (date: Date | string): string => {
     if (!date) return 'Invalid date';
     const options: Intl.DateTimeFormatOptions = {
@@ -82,18 +95,17 @@ const EventCard: React.FC<EventPreviewProps> = ({
     return `${formattedStartTime} - ${formattedEndTime}`;
   };
 
-  const backgroundImage = event.eventImage || '/beaver-eventcard.jpeg';
-
   return (
     <div className={style.eventCard} onClick={onClick}>
       <div className={style.imageWrapper}>
         <Image
-          src={backgroundImage}
+          src={imageSrc}
           alt="Event cover"
           layout="fill"
           objectFit="cover"
           objectPosition="center"
           className={style.eventImage}
+          onError={() => setImageSrc('/beaver-eventcard.jpeg')}
         />
       </div>
       <div className={style.eventTitle}>

--- a/src/app/components/EventCard.tsx
+++ b/src/app/components/EventCard.tsx
@@ -53,6 +53,10 @@ const EventCard: React.FC<EventPreviewProps> = ({
   const initialImage = isValidUrl(event.eventImage) ? event.eventImage! : '/beaver-eventcard.jpeg';
   const [imageSrc, setImageSrc] = useState<string>(initialImage);
 
+  const handleImageError = () => {
+    setImageSrc('/beaver-eventcard.jpeg');
+  };
+
   const formatDate = (date: Date | string): string => {
     if (!date) return 'Invalid date';
     const options: Intl.DateTimeFormatOptions = {
@@ -105,7 +109,7 @@ const EventCard: React.FC<EventPreviewProps> = ({
           objectFit="cover"
           objectPosition="center"
           className={style.eventImage}
-          onError={() => setImageSrc('/beaver-eventcard.jpeg')}
+          onError={handleImageError}
         />
       </div>
       <div className={style.eventTitle}>


### PR DESCRIPTION
## Developer: Anikait Vishwanathan

Closes #299 

### Pull Request Summary

Adding error handling for invalid image URL link

### Modifications

Homepage and event card component

### Testing Considerations

Replace a test event's image with the exact broken URL and ensure that it initially displayed as invalid and that the default image replaced this. 

Made sure that these changes showed up on both on the edit events admin page and on the homepage of the site. 

Also replaced the broken URL with a valid image link to ensure that correct image URLs are not incorrectly replaced

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}
