### PR TITLE
300 admin can view waivers

### DIFF
--- a/src/app/admin/events/edit/[eventId]/page.module.css
+++ b/src/app/admin/events/edit/[eventId]/page.module.css
@@ -156,8 +156,22 @@
     text-decoration-line: underline;
 }
 
+.waiverColumn {
+    width: 120px;
+    text-align: left;
+    padding-right: 10px;
+}
+
+.linkGroup {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    white-space: nowrap;
+  }
+
 .visitorTable {
-    table-layout: fixed;
+    width: 100%;
+    table-layout: auto;
 }
 
 .visitorInfoSmallHeader {

--- a/src/app/admin/events/edit/[eventId]/page.module.css
+++ b/src/app/admin/events/edit/[eventId]/page.module.css
@@ -154,12 +154,22 @@
 
 .detailsColumn:hover {
     text-decoration-line: underline;
+    
 }
 
 .waiverColumn {
-    width: 120px;
+    padding: 1.5% 0% 1.5% 3%;
     text-align: left;
-    padding-right: 10px;
+    width: 20%;
+    font-size: 15px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    margin-right: 3%;
+}
+
+.waiverColumn:hover {
+    text-decoration-line: underline;
 }
 
 .linkGroup {

--- a/src/app/admin/events/edit/[eventId]/page.tsx
+++ b/src/app/admin/events/edit/[eventId]/page.tsx
@@ -23,10 +23,10 @@ export default function EditEventsPage({ params: { eventId } }: IParams) {
       <EditEventHeader eventId={eventId} />
       <Flex
         className={styles.temp}
-        direction={{ base: "column", md: "row" }}
+        direction={{ base: "column", xl: "row" }}
         justify="space-between"
       >
-        <Box className={styles.leftColumn} w={{ base: "100%", md: "38%" }}>
+        <Box className={styles.leftColumn} w={{ base: "100%", xl: "38%" }}>
           <EditEventVisitorInfo eventId={eventId} />
           <Box className={styles.imageContainer}>
             <img
@@ -35,7 +35,7 @@ export default function EditEventsPage({ params: { eventId } }: IParams) {
             ></img>
           </Box>
         </Box>
-        <Box className={styles.rightColumn} w={{ base: "100%", md: "58%" }}>
+        <Box className={styles.rightColumn} w={{ base: "100%", xl: "58%" }}>
           <EditEventPrimaryInfo eventId={eventId} />
         </Box>
       </Flex>

--- a/src/app/components/EditEventVisitorInfo.tsx
+++ b/src/app/components/EditEventVisitorInfo.tsx
@@ -16,6 +16,7 @@ import { ISignedWaiver } from 'database/signedWaiverSchema';
 import { removeAttendee, removeRegistered } from 'app/actions/serveractions';
 import { addAttendee } from 'app/actions/useractions';
 import SingleVisitorComponent from './SingleVisitorComponent';
+import SingleVistorWaiver from './SingleVisitorWaiver';
 import { useEventId } from 'app/lib/swrfunctions';
 
 const placeholderUser: IUser = {
@@ -415,26 +416,11 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
           )}
         </>
       )}
-      {selectedWaiver && (
-        <div>
-          <Modal isOpen={isWaiverModalOpen} onClose={closeWaiverModal}>
-            <ModalOverlay />
-            <ModalContent>
-              <ModalHeader>Signed Waiver</ModalHeader>
-              <ModalCloseButton />
-              <ModalBody>
-                <Text>
-                  <strong>Name:</strong> {selectedWaiver.signeeName}
-                </Text>
-                <Text>
-                  <strong>Date Signed:</strong>{" "}
-                  {new Date(selectedWaiver.dateSigned).toLocaleDateString()}
-                </Text>
-              </ModalBody>
-            </ModalContent>
-          </Modal>
-        </div>
-      )}
+      <SingleVistorWaiver
+        isOpen={isWaiverModalOpen}
+        onClose={closeWaiverModal}
+        waiver={selectedWaiver}
+      />
     </Box>
   );
 };

--- a/src/app/components/EditEventVisitorInfo.tsx
+++ b/src/app/components/EditEventVisitorInfo.tsx
@@ -1,12 +1,17 @@
 'use client';
 
-import { Box, Spinner, Checkbox, useDisclosure, Modal,
+import {
+  Box,
+  Spinner,
+  Checkbox,
+  useDisclosure,
+  Modal,
   ModalOverlay,
   ModalContent,
   ModalHeader,
   ModalBody,
   ModalCloseButton,
-  Text 
+  Text,
 } from '@chakra-ui/react';
 import React, { useState, useEffect } from 'react';
 import styles from '../styles/admin/editEvent.module.css';
@@ -46,15 +51,17 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
   const [selectedVisitors, setSelectedVisitors] = useState<IUser[]>([]);
   const [waivers, setWaivers] = useState<ISignedWaiver[]>([]);
   const [waiverVersions, setWaiverVersions] = useState<IWaiverVersion[]>([]);
-  const [selectedWaiver, setSelectedWaiver] = useState<ISignedWaiver | null>(null);
+  const [selectedWaiver, setSelectedWaiver] = useState<ISignedWaiver | null>(
+    null
+  );
   const {
     isOpen: isWaiverModalOpen,
     onOpen: openWaiverModal,
     onClose: closeWaiverModal,
   } = useDisclosure();
 
-  const openWaiver = async (userId: string) => { 
-    const waiver = waivers.find(w => w.signeeId === userId);
+  const openWaiver = async (userId: string) => {
+    const waiver = waivers.find((w) => w.signeeId === userId);
     setSelectedWaiver(waiver ?? null);
     if (waiver) {
       try {
@@ -69,7 +76,7 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
       }
     }
     openWaiverModal();
-};
+  };
 
   const emailLink = () => {
     const emails = Object.values(visitorData)
@@ -110,13 +117,13 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
     setShowAdminActions(false);
   };
 
-  async function handleMarkSelectVisitors(){
+  async function handleMarkSelectVisitors() {
     //no functionality yet
     for (const visitor of selectedVisitors) {
       await addAttendee(visitor._id.toString(), eventId.toString());
     }
     setShowAdminActions(false);
-  };
+  }
 
   async function handleRemoveSelectedAttendees() {
     for (const visitor of selectedVisitors) {
@@ -153,7 +160,7 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
       }
     }
   }
-  
+
   useEffect(() => {
     if (isLoading) {
       return;
@@ -285,13 +292,14 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
               }, 0)}
               )
             </div>
-            <button 
+            <button
               onClick={() => setShowAdminActions(!showAdminActions)}
-              className={styles.manageVisitorText}>
-              {(showAdminActions) ? "Hide Admin Actions" : "Show Admin Actions"}
+              className={styles.manageVisitorText}
+            >
+              {showAdminActions ? 'Hide Admin Actions' : 'Show Admin Actions'}
             </button>
           </div>
-          {showAdminActions && 
+          {showAdminActions && (
             <div className={styles.manageVisitorContainer}>
               <div className={styles.manageVisitorRow}>
                 <button
@@ -337,7 +345,7 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
                 </button>
               </div>
             </div>
-          }
+          )}
           {Object.keys(visitorData).length === 0 ? (
             <div className={styles.noVisitorsMessage}>
               No visitors registered for this event.
@@ -345,6 +353,15 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
           ) : (
             <div className={styles.tableContainer}>
               <table className={styles.visitorTable}>
+                <thead>
+                  <tr className={styles.visitorRow}>
+                    <th className={styles.checkBox}></th>
+                    <th className={styles.nameColumn}>Name</th>
+                    <th className={styles.emailColumn}>Email</th>
+                    <th className={styles.detailsColumn}>Waiver Status</th>
+                    <th className={styles.detailsColumn}>Details</th>
+                  </tr>
+                </thead>
                 <tbody>
                   {sortedVisitorEntries.map(
                     ([parentId, group], parentIndex) => (
@@ -379,24 +396,29 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
                               {group.parent.email ? group.parent.email : 'N/A'}
                             </td>
                             <td className={styles.detailsColumn}>
-                              <div className={styles.linkGroup}>
-                                <div className={styles.link}>
-                                {waivers.some(w => w.signeeId === group.parent._id) ? (
+                                {waivers.some(
+                                  (w) => w.signeeId === group.parent._id
+                                ) ? (
                                   <span
+                                    className={styles.link}
                                     style={{
-                                      cursor: 'pointer'
+                                      cursor: 'pointer',
                                     }}
                                     onClick={() => openWaiver(group.parent._id)}
                                   >
                                     Signed
                                   </span>
                                 ) : (
-                                  <span>Unsigned</span>
+                                  <p>Unsigned</p>
                                 )}
-                                </div>
-                                <SingleVisitorComponent visitorData={group.parent} />
+                            </td>
+                            <td className={styles.detailsColumn}>
+                              <div className={styles.linkGroup}>
+                                <SingleVisitorComponent
+                                  visitorData={group.parent}
+                                />
                               </div>
-                          </td>
+                            </td>
                           </tr>
                         )}
                         {group.dependents
@@ -435,7 +457,9 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
         onClose={closeWaiverModal}
         waiver={selectedWaiver}
         waiverVersion={
-          waiverVersions?.find(v => v.version === selectedWaiver?.waiverVersion) || null
+          waiverVersions?.find(
+            (v) => v.version === selectedWaiver?.waiverVersion
+          ) || null
         }
       />
     </Box>

--- a/src/app/components/EditEventVisitorInfo.tsx
+++ b/src/app/components/EditEventVisitorInfo.tsx
@@ -35,6 +35,7 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
   const { eventData, isLoading, isError } = useEventId(eventId);
   const [showAdminActions, setShowAdminActions] = useState(false);
   const [selectedVisitors, setSelectedVisitors] = useState<IUser[]>([]);
+  const [waivers, setWaivers] = useState<ISignedWaiver[]>([]);
 
   const emailLink = () => {
     const emails = Object.values(visitorData)
@@ -136,10 +137,11 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
         try {
           const waiverResponse = await fetch(`/api/waiver/${eventId}`);
           if (waiverResponse.ok) {
-            const waivers = await waiverResponse.json();
+            const fetchedWaivers = await waiverResponse.json();
+            setWaivers(fetchedWaivers);
 
             debugger;
-            waivers.forEach((waiver: ISignedWaiver) => {
+            fetchedWaivers.forEach((waiver: ISignedWaiver) => {
               if (!visitors[waiver.signeeId]) {
                 visitors[waiver.signeeId] = {
                   parent: placeholderUser,
@@ -343,10 +345,24 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
                               {group.parent.email ? group.parent.email : 'N/A'}
                             </td>
                             <td className={styles.detailsColumn}>
-                              <SingleVisitorComponent
-                                visitorData={group.parent}
-                              />
-                            </td>
+                              <div className={styles.linkGroup}>
+                                {waivers.some(w => w.signeeId === group.parent._id) ? (
+                                  <span
+                                    style={{
+                                      color: '#2b6cb0',
+                                      cursor: 'pointer',
+                                      textDecoration: 'underline',
+                                    }}
+                                    onClick={() => openWaiverForUser(group.parent._id)}
+                                  >
+                                    Signed
+                                  </span>
+                                ) : (
+                                  <span>Unsigned</span>
+                                )}
+                                <SingleVisitorComponent visitorData={group.parent} />
+                              </div>
+                          </td>
                           </tr>
                         )}
                         {group.dependents

--- a/src/app/components/EditEventVisitorInfo.tsx
+++ b/src/app/components/EditEventVisitorInfo.tsx
@@ -346,20 +346,20 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
                             </td>
                             <td className={styles.detailsColumn}>
                               <div className={styles.linkGroup}>
+                                <div className={styles.link}>
                                 {waivers.some(w => w.signeeId === group.parent._id) ? (
                                   <span
                                     style={{
-                                      color: '#2b6cb0',
-                                      cursor: 'pointer',
-                                      textDecoration: 'underline',
+                                      cursor: 'pointer'
                                     }}
-                                    onClick={() => openWaiverForUser(group.parent._id)}
+                                    onClick={() => openWaiver(group.parent._id)}
                                   >
                                     Signed
                                   </span>
                                 ) : (
                                   <span>Unsigned</span>
                                 )}
+                                </div>
                                 <SingleVisitorComponent visitorData={group.parent} />
                               </div>
                           </td>

--- a/src/app/components/EditEventVisitorInfo.tsx
+++ b/src/app/components/EditEventVisitorInfo.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { Box, Spinner, Checkbox } from '@chakra-ui/react';
+import { Box, Spinner, Checkbox, useDisclosure, Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalCloseButton,
+  Text 
+} from '@chakra-ui/react';
 import React, { useState, useEffect } from 'react';
 import styles from '../styles/admin/editEvent.module.css';
 import { IEvent } from '@database/eventSchema';
@@ -36,6 +43,18 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
   const [showAdminActions, setShowAdminActions] = useState(false);
   const [selectedVisitors, setSelectedVisitors] = useState<IUser[]>([]);
   const [waivers, setWaivers] = useState<ISignedWaiver[]>([]);
+  const [selectedWaiver, setSelectedWaiver] = useState<ISignedWaiver | null>(null);
+  const {
+    isOpen: isWaiverModalOpen,
+    onOpen: openWaiverModal,
+    onClose: closeWaiverModal,
+  } = useDisclosure();
+
+  const openWaiver = (userId: string) => {
+    const waiver = waivers.find(w => w.signeeId === userId);
+    setSelectedWaiver(waiver ?? null);
+    openWaiverModal();
+  }
 
   const emailLink = () => {
     const emails = Object.values(visitorData)
@@ -395,6 +414,26 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
             </div>
           )}
         </>
+      )}
+      {selectedWaiver && (
+        <div>
+          <Modal isOpen={isWaiverModalOpen} onClose={closeWaiverModal}>
+            <ModalOverlay />
+            <ModalContent>
+              <ModalHeader>Signed Waiver</ModalHeader>
+              <ModalCloseButton />
+              <ModalBody>
+                <Text>
+                  <strong>Name:</strong> {selectedWaiver.signeeName}
+                </Text>
+                <Text>
+                  <strong>Date Signed:</strong>{" "}
+                  {new Date(selectedWaiver.dateSigned).toLocaleDateString()}
+                </Text>
+              </ModalBody>
+            </ModalContent>
+          </Modal>
+        </div>
       )}
     </Box>
   );

--- a/src/app/components/SingleVisitorComponent.tsx
+++ b/src/app/components/SingleVisitorComponent.tsx
@@ -115,7 +115,7 @@ function SingleVisitorComponent({ visitorData, removeFunction, adminData}: Singl
   return (
     <>
       <div className={styles.link}>
-        <Text onClick={onOpen}>Details</Text>
+        <Text onClick={onOpen} cursor="pointer">Details</Text>
       </div>
       <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />

--- a/src/app/components/SingleVisitorComponent.tsx
+++ b/src/app/components/SingleVisitorComponent.tsx
@@ -1,5 +1,5 @@
-"use client";
-import React, { useState, useEffect } from "react";
+'use client';
+import React, { useState, useEffect } from 'react';
 import {
   Box,
   Text,
@@ -20,15 +20,15 @@ import {
   useDisclosure,
   Icon,
   Center,
-} from "@chakra-ui/react";
-import styles from "../styles/admin/editEvent.module.css";
-import { IUser } from "@database/userSchema";
-import { IEvent } from "database/eventSchema";
-import { eventIndividualHours } from ".././lib/hours";
-import {makeUserAdmin} from "../actions/makeUserAdmin";
-import makeAdminUser from "../actions/makeAdminUser";
-import DeleteConfirmation from "./DeleteConfirmation";
-
+} from '@chakra-ui/react';
+import styles from '../styles/admin/editEvent.module.css';
+import { IUser } from '@database/userSchema';
+import { IEvent } from 'database/eventSchema';
+import { eventIndividualHours } from '.././lib/hours';
+import { makeUserAdmin } from '../actions/makeUserAdmin';
+import makeAdminUser from '../actions/makeAdminUser';
+import DeleteConfirmation from './DeleteConfirmation';
+import { PiKeyReturnLight } from 'react-icons/pi';
 
 interface SingleVisitorComponentProps {
   visitorData: IUser;
@@ -36,139 +36,154 @@ interface SingleVisitorComponentProps {
   removeFunction?: (userId: string) => void;
 }
 
-function SingleVisitorComponent({ visitorData, removeFunction, adminData}: SingleVisitorComponentProps) {
+function SingleVisitorComponent({
+  visitorData,
+  removeFunction,
+  adminData,
+}: SingleVisitorComponentProps) {
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const [isClosed, setIsClosed] = useState(false);
   const [events, setEvents] = useState<IEvent[]>([]);
   const [loading, setLoading] = useState(true);
   const [userRole, setUserRole] = useState(visitorData.role);
 
-
   useEffect(() => {
-    const fetchEvents = async () => {
-      setLoading(true);
-      try {
-        const eventIds = visitorData.eventsAttended.map((e) => e.eventId);
-        const fetchedEvents = await Promise.all(
-          eventIds.map((id, idx) =>
-            fetch(`/api/events/${id}`)
-              .then((res) => res.json())
-              .then((data) => {
-                return {
-                  ...data,
-                  attendeeIds: data.attendeeIds || [],
-                  startTime: visitorData.eventsAttended[idx].startTime,
-                  endTime: visitorData.eventsAttended[idx].endTime,
-                };
-              })
-          )
-        );
-        setEvents(fetchedEvents);
-      } catch (error) {
-        console.error("Failed to fetch events:", error);
-      }
-      setLoading(false);
-    };
+    if (isOpen) {
+      const fetchEvents = async () => {
+        setLoading(true);
+        try {
+          const eventIds = visitorData.eventsAttended.map((e) => e.eventId);
+          const fetchedEvents = await Promise.all(
+            eventIds.map((id, idx) =>
+              fetch(`/api/events/${id}`)
+                .then((res) => res.json())
+                .then((data) => {
+                  return {
+                    ...data,
+                    attendeeIds: data.attendeeIds || [],
+                    startTime: visitorData.eventsAttended[idx].startTime,
+                    endTime: visitorData.eventsAttended[idx].endTime,
+                  };
+                })
+            )
+          );
+          setEvents(fetchedEvents);
+        } catch (error) {
+          console.error('Failed to fetch events:', error);
+        }
+        setLoading(false);
+      };
 
-    if (
-      visitorData &&
-      visitorData.eventsAttended &&
-      visitorData.eventsAttended.length > 0
-    ) {
-      fetchEvents();
+      if (
+        visitorData &&
+        visitorData.eventsAttended &&
+        visitorData.eventsAttended.length > 0
+      ) {
+        fetchEvents();
+      }
     }
   }, [visitorData]);
-
-
 
   const formatDate = (date: Date) => {
     return new Date(date).toLocaleDateString();
   };
 
   const handleRoleChange = async () => {
-
     try {
       const result =
-        userRole === "admin"
+        userRole === 'admin'
           ? await makeAdminUser(visitorData.email)
-          : await makeUserAdmin(visitorData.email, "admin");
+          : await makeUserAdmin(visitorData.email, 'admin');
       setUserRole(result.role);
     } catch (error) {
-      console.error("Error updating role:", error);
+      console.error('Error updating role:', error);
     }
   };
 
   const handleSuperAdminButton = async () => {
     try {
-      const result = await makeUserAdmin(visitorData.email, "super-admin");
+      const result = await makeUserAdmin(visitorData.email, 'super-admin');
       setUserRole(result.role);
     } catch (error) {
-      console.error("Error making super admin: ", error);
+      console.error('Error making super admin: ', error);
     }
-  }
+  };
 
   const closeFromChild = () => {
     onClose();
   };
 
-
-
   return (
     <>
       <div className={styles.link}>
-        <Text onClick={onOpen} cursor="pointer">Details</Text>
+        <Text onClick={onOpen} cursor="pointer">
+          Details
+        </Text>
       </div>
       <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent
-          style={{ width: "60vw", height: "65vh", overflow: "auto" }}
+          style={{ width: "60vw", height: "50vh", overflow: "auto" }}
           maxW="100rem"
         >
           <ModalHeader
             style={{
-              padding: "1% 5%",
-              textAlign: "left",
-              fontSize: "35px",
-              fontWeight: "bold",
-              fontFamily: "Lato",
-              width: "100%",
+              padding: '1% 5%',
+              textAlign: 'left',
+              fontSize: '35px',
+              fontWeight: 'bold',
+              fontFamily: 'Lato',
+              width: '100%',
             }}
           >
             <Flex direction="column" align="left" p={4}>
               <Text>
                 {visitorData.firstName} {visitorData.lastName}
               </Text>
-
             </Flex>
           </ModalHeader>
           <ModalCloseButton />
           <hr />
           <ModalBody
-            style={{ display: "flex", flexDirection: "column", padding: "0%" }}
+            style={{ display: 'flex', flexDirection: 'column', padding: '0%' }}
             className={styles.parentContainer}
           >
-            <Box className={styles.infoBox} >
+            <Box className={styles.infoBox}>
               <Text className={styles.visitorInfoSmallHeader}>
                 Account Info
               </Text>
-              <div style={{ display: "flex" }} className={styles.accountInfo}>
-                <div style={{ width: "45%" }}>
+              <div style={{ display: 'flex' }} className={styles.accountInfo}>
+                <div style={{ width: '45%' }}>
                   <Text className={styles.fieldInfo}>
-                    <Text as="span" className={styles.boldText}>Email</Text> <br></br> {visitorData.email ? visitorData.email : "N/A"}
+                    <Text as="span" className={styles.boldText}>
+                      Email
+                    </Text>{' '}
+                    <br></br> {visitorData.email ? visitorData.email : 'N/A'}
                   </Text>
                   <Text className={styles.fieldInfo}>
-                    <Text as="span" className={styles.boldText}>Zipcode</Text><br></br> {visitorData.zipcode ? visitorData.zipcode : "N/A"}
+                    <Text as="span" className={styles.boldText}>
+                      Zipcode
+                    </Text>
+                    <br></br>{' '}
+                    {visitorData.zipcode ? visitorData.zipcode : 'N/A'}
                   </Text>
                 </div>
-                <div style={{ width: "45%" }}>
+                <div style={{ width: '45%' }}>
                   <Text className={styles.fieldInfo}>
-                    <Text as="span" className={styles.boldText}>Phone</Text> <br></br> {visitorData.phoneNumber ? visitorData.phoneNumber : "N/A"}
+                    <Text as="span" className={styles.boldText}>
+                      Phone
+                    </Text>{' '}
+                    <br></br>{' '}
+                    {visitorData.phoneNumber ? visitorData.phoneNumber : 'N/A'}
                   </Text>
                   <Text className={styles.fieldInfo}>
-                    <Text as="span" className={styles.boldText}>Receive Newsletter</Text> <br></br> {visitorData.receiveNewsletter ? "Yes" : "No"}
+                    <Text as="span" className={styles.boldText}>
+                      Receive Newsletter
+                    </Text>{' '}
+                    <br></br> {visitorData.receiveNewsletter ? 'Yes' : 'No'}
                   </Text>
                 </div>
               </div>
-
             </Box>
             <Box className={styles.infoBox}>
               <Text className={styles.visitorInfoSmallHeader}>
@@ -198,52 +213,65 @@ function SingleVisitorComponent({ visitorData, removeFunction, adminData}: Singl
                   </Table>
                 </div>
               ) : (
-                <Text className={styles.fieldInfo} style={{ textAlign: "center" }}>
-                  <Text as="span" className={styles.boldText}>No Events Attended</Text>
+                <Text
+                  className={styles.fieldInfo}
+                  style={{ textAlign: 'center' }}
+                >
+                  <Text as="span" className={styles.boldText}>
+                    No Events Attended
+                  </Text>
                 </Text>
               )}
             </Box>
             <Flex direction="row" align="center" justify="center" gap={8} p={4}>
-                {userRole !== "guest" && (
-                  <>
-                    {adminData?.role === "super-admin" && userRole !== "super-admin" && (
+              {userRole !== 'guest' && (
+                <>
+                  {adminData?.role === 'super-admin' &&
+                    userRole !== 'super-admin' && (
                       <Button
                         mt={2}
                         color="#337774"
                         bg="white"
                         border="2px"
-                        _hover={{ bg: "#337774", color: "white" }}
+                        _hover={{ bg: '#337774', color: 'white' }}
                         onClick={handleSuperAdminButton}
                       >
                         Make Super Admin
                       </Button>
                     )}
-                    {userRole !== "admin" && (
-                      <Button
-                        mt={2}
-                        color="#337774"
-                        bg="white"
-                        border="2px"
-                        _hover={{ bg: "#337774", color: "white" }}
-                        onClick={handleRoleChange}
-                      >
-                        Make Admin
-                      </Button>
-                    )}
-                    {userRole !== "user" && (
-                      <Button
-                        mt={2}
-                        bg="#E0AF48"
-                        color="black"
-                        _hover={{ bg: "#C19137", color: "black" }}
-                        onClick={handleRoleChange}
-                      >
-                        Revert to User
-                      </Button>
-                    )}
-                  </>
-                )}
-              <DeleteConfirmation closeFromChild={closeFromChild} userData={visitorData} isSelf={false} removeFunction={removeFunction}> </DeleteConfirmation>
+                  {userRole !== 'admin' && (
+                    <Button
+                      mt={2}
+                      color="#337774"
+                      bg="white"
+                      border="2px"
+                      _hover={{ bg: '#337774', color: 'white' }}
+                      onClick={handleRoleChange}
+                    >
+                      Make Admin
+                    </Button>
+                  )}
+                  {userRole !== 'user' && (
+                    <Button
+                      mt={2}
+                      bg="#E0AF48"
+                      color="black"
+                      _hover={{ bg: '#C19137', color: 'black' }}
+                      onClick={handleRoleChange}
+                    >
+                      Revert to User
+                    </Button>
+                  )}
+                </>
+              )}
+              <DeleteConfirmation
+                closeFromChild={closeFromChild}
+                userData={visitorData}
+                isSelf={false}
+                removeFunction={removeFunction}
+              >
+                {' '}
+              </DeleteConfirmation>
             </Flex>
           </ModalBody>
         </ModalContent>

--- a/src/app/components/SingleVisitorWaiver.tsx
+++ b/src/app/components/SingleVisitorWaiver.tsx
@@ -1,0 +1,44 @@
+"use client";
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  Text
+} from "@chakra-ui/react";
+import { ISignedWaiver } from "database/signedWaiverSchema";
+
+interface SignedWaiverModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  waiver: ISignedWaiver | null;
+}
+
+export default function SignedWaiverModal({
+  isOpen,
+  onClose,
+  waiver,
+}: SignedWaiverModalProps) {
+  if (!waiver) return null;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Signed Waiver</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Text>
+            <strong>Name:</strong> {waiver.signeeName}
+          </Text>
+          <Text>
+            <strong>Date Signed:</strong>{" "}
+            {new Date(waiver.dateSigned).toLocaleDateString()}
+          </Text>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/app/components/SingleVisitorWaiver.tsx
+++ b/src/app/components/SingleVisitorWaiver.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import {
   Modal,
   ModalOverlay,
@@ -10,22 +10,11 @@ import {
   Flex,
   Box,
   Divider,
-  Textarea
-} from "@chakra-ui/react";
-import { ISignedWaiver } from "database/signedWaiverSchema";
+  Textarea,
+} from '@chakra-ui/react';
+import { ISignedWaiver } from 'database/signedWaiverSchema';
 import WaiverVersion, { IWaiverVersion } from '@database/waiverVersionsSchema';
-import styles from "../styles/admin/editEvent.module.css";
-
-const waiverText = `1. I am voluntarily joining an activity sponsored by the SLO Beaver Brigade, which may include tours to and from and in and around beaver ponds, as well as litter and brush removal or planting in riverbeds and creekbeds, and related activities.
-
-2. I understand that the SLO Beaver Brigade has no duty or responsibility for me or my dependents’ safety or property. I am participating in this activity entirely at my own risk and assume full responsibility for any and all bodily injury, disability, death, or property damage as a result of my participation in a SLO Beaver Brigade event. I recognize that these risks may include hiking, crossing streams or wading through water, falling trees and limbs, poison oak, stinging nettles, thistles and other barbed plants, poisonous insects, snakes including rattlesnakes, ticks, wild animals, inclement weather, wildfires or floods, homeless encampments, sharp objects in and around the riverbed such as barbed wire, unsupervised dogs or horses, ATV riders, dirt bikers or other vehicles, hunters, target shooters, poachers, and any other risks on or around the premises of the activity, known or unknown to me or event organizers and leaders.
-
-3. I hereby RELEASE, WAIVE, and DISCHARGE the SLO Beaver Brigade, Dr. Emily Fairfax, Audrey Taub, Cooper Lienhart, Kate Montgomery, Fred Frank, Hannah Strauss, landowners, and Beaver Brigade interns/fellows, volunteers, members, sponsors, affiliates and other agents from any and all liability, claims, demands and actions whatsoever, regardless of whether such loss is caused by the acts or failures to act of any party organizing or leading a specific event or activity on behalf of the SLO Beaver Brigade, and I surrender any and all rights to seek compensation for any injury whatsoever sustained during my participation in a SLO Beaver Brigade activity. I agree to INDEMNIFY and HOLD HARMLESS releases against any and all claims, suits, or actions brought by me, my spouse, family, heirs, or anyone else on behalf of me or my dependents, and agree to reimburse all attorney’s fees and related costs that may be incurred by releases due to my participation in SLO Beaver Brigade events or activities.
-
-4. I hereby grant the SLO Beaver Brigade permission to use my likeness in a photograph, video, or other digital media (“photo”) in any and all of its publications, including web-based publications, without payment or other consideration. I hereby irrevocably authorize the SLO Beaver Brigade to edit, alter, copy, exhibit, publish, or distribute these photos for any lawful purpose. In addition, I waive any right to inspect or approve the finished product wherein my likeness appears. Additionally, I waive any right to royalties or other compensation arising from or related to the use of the photo.`;
-
-const signatureText = `BY SIGNING THIS AGREEMENT, I ACKNOWLEDGE AND REPRESENT THAT I HAVE READ THIS WAIVER OF LIABILITY AND HOLD HARMLESS AGREEMENT, that I fully understand and consent to the terms of this agreement, and that I am signing it of my own free will. I agree that no oral representations, statements, or inducements apart from this written agreement have been made or implied. I am at least 18 years of age, fully competent, responsible, and legally able to sign this agreement for myself or my dependents.`;
-
+import styles from '../styles/admin/editEvent.module.css';
 
 interface SignedWaiverModalProps {
   isOpen: boolean;
@@ -46,17 +35,17 @@ export default function SignedWaiverModal({
     <Modal isOpen={isOpen} onClose={onClose} size="xl" scrollBehavior="inside">
       <ModalOverlay />
       <ModalContent
-        style={{ width: "60vw", height: "65vh", overflow: "auto" }}
-        maxW="100rem"
+        style={{ width: '80vw', height: '65vh', overflow: 'auto' }}
+        maxW="80vw"
       >
         <ModalHeader
           style={{
-            padding: "1% 5%",
-            textAlign: "left",
-            fontSize: "35px",
-            fontWeight: "bold",
-            fontFamily: "Lato",
-            width: "100%",
+            padding: '1% 5%',
+            textAlign: 'left',
+            fontSize: '35px',
+            fontWeight: 'bold',
+            fontFamily: 'Lato',
+            width: '100%',
           }}
         >
           <Flex direction="column" align="left" p={4}>
@@ -65,7 +54,7 @@ export default function SignedWaiverModal({
         </ModalHeader>
         <ModalCloseButton />
         <ModalBody
-          style={{ display: "flex", flexDirection: "column", padding: "0%" }}
+          style={{ display: 'flex', flexDirection: 'column', padding: '0%' }}
           className={styles.parentContainer}
         >
           {waiverVersion ? (
@@ -76,7 +65,7 @@ export default function SignedWaiverModal({
               <Textarea
                 value={waiverVersion.body}
                 readOnly
-                height="200px"
+                height="400px"
                 resize="none"
                 whiteSpace="pre-line"
                 className={styles.scroller}
@@ -86,33 +75,44 @@ export default function SignedWaiverModal({
                 {waiverVersion.acknowledgement}
               </Text>
               <Flex mt={6} justify="space-between" wrap="wrap">
-              <div style={{ width: "45%" }}>
-                <Text className={styles.fieldInfo}>
-                  <Text as="span" className={styles.boldText}>Signed by</Text><br />
-                  {waiver.signeeName}
-                </Text>
-              </div>
-              <div style={{ width: "45%" }}>
-                <Text className={styles.fieldInfo}>
-                  <Text as="span" className={styles.boldText}>Date Signed</Text><br />
-                  {new Date(waiver.dateSigned).toLocaleDateString()}
-                </Text>
-              </div>
+                <div style={{ width: '45%' }}>
+                  <Text className={styles.fieldInfo}>
+                    <Text as="span" className={styles.boldText}>
+                      Signed by
+                    </Text>
+                    <br />
+                    {waiver.signeeName}
+                  </Text>
+                </div>
+                <div style={{ width: '45%' }}>
+                  <Text className={styles.fieldInfo}>
+                    <Text as="span" className={styles.boldText}>
+                      Date Signed
+                    </Text>
+                    <br />
+                    {new Date(waiver.dateSigned).toLocaleDateString()}
+                  </Text>
+                </div>
               </Flex>
               {waiver.dependents.length > 0 && (
-                <div style={{ width: "45%" }}>
-                    <Text className={styles.fieldInfo}>
-                        <Text as="span" className={styles.boldText}>Dependents</Text><br />
-                            {waiver.dependents.map((dep, idx) => (
-                            <Text key={idx}>{dep}</Text>
-                            ))}
+                <div style={{ width: '45%' }}>
+                  <Text className={styles.fieldInfo}>
+                    <Text as="span" className={styles.boldText}>
+                      Dependents
                     </Text>
+                    <br />
+                    {waiver.dependents.map((dep, idx) => (
+                      <Text key={idx}>{dep}</Text>
+                    ))}
+                  </Text>
                 </div>
-                )}
+              )}
             </Box>
           ) : (
             <Box className={styles.infoBox}>
-              <Text className={styles.visitorInfoSmallHeader}>Terms and Conditions</Text>
+              <Text className={styles.visitorInfoSmallHeader}>
+                Terms and Conditions
+              </Text>
               <Text className={styles.fieldInfo}>Waiver not found.</Text>
             </Box>
           )}

--- a/src/app/components/SingleVisitorWaiver.tsx
+++ b/src/app/components/SingleVisitorWaiver.tsx
@@ -8,29 +8,45 @@ import {
   ModalBody,
   Text,
   Flex,
-  Box
+  Box,
+  Divider,
+  Textarea
 } from "@chakra-ui/react";
 import { ISignedWaiver } from "database/signedWaiverSchema";
+import WaiverVersion, { IWaiverVersion } from '@database/waiverVersionsSchema';
 import styles from "../styles/admin/editEvent.module.css";
+
+const waiverText = `1. I am voluntarily joining an activity sponsored by the SLO Beaver Brigade, which may include tours to and from and in and around beaver ponds, as well as litter and brush removal or planting in riverbeds and creekbeds, and related activities.
+
+2. I understand that the SLO Beaver Brigade has no duty or responsibility for me or my dependents’ safety or property. I am participating in this activity entirely at my own risk and assume full responsibility for any and all bodily injury, disability, death, or property damage as a result of my participation in a SLO Beaver Brigade event. I recognize that these risks may include hiking, crossing streams or wading through water, falling trees and limbs, poison oak, stinging nettles, thistles and other barbed plants, poisonous insects, snakes including rattlesnakes, ticks, wild animals, inclement weather, wildfires or floods, homeless encampments, sharp objects in and around the riverbed such as barbed wire, unsupervised dogs or horses, ATV riders, dirt bikers or other vehicles, hunters, target shooters, poachers, and any other risks on or around the premises of the activity, known or unknown to me or event organizers and leaders.
+
+3. I hereby RELEASE, WAIVE, and DISCHARGE the SLO Beaver Brigade, Dr. Emily Fairfax, Audrey Taub, Cooper Lienhart, Kate Montgomery, Fred Frank, Hannah Strauss, landowners, and Beaver Brigade interns/fellows, volunteers, members, sponsors, affiliates and other agents from any and all liability, claims, demands and actions whatsoever, regardless of whether such loss is caused by the acts or failures to act of any party organizing or leading a specific event or activity on behalf of the SLO Beaver Brigade, and I surrender any and all rights to seek compensation for any injury whatsoever sustained during my participation in a SLO Beaver Brigade activity. I agree to INDEMNIFY and HOLD HARMLESS releases against any and all claims, suits, or actions brought by me, my spouse, family, heirs, or anyone else on behalf of me or my dependents, and agree to reimburse all attorney’s fees and related costs that may be incurred by releases due to my participation in SLO Beaver Brigade events or activities.
+
+4. I hereby grant the SLO Beaver Brigade permission to use my likeness in a photograph, video, or other digital media (“photo”) in any and all of its publications, including web-based publications, without payment or other consideration. I hereby irrevocably authorize the SLO Beaver Brigade to edit, alter, copy, exhibit, publish, or distribute these photos for any lawful purpose. In addition, I waive any right to inspect or approve the finished product wherein my likeness appears. Additionally, I waive any right to royalties or other compensation arising from or related to the use of the photo.`;
+
+const signatureText = `BY SIGNING THIS AGREEMENT, I ACKNOWLEDGE AND REPRESENT THAT I HAVE READ THIS WAIVER OF LIABILITY AND HOLD HARMLESS AGREEMENT, that I fully understand and consent to the terms of this agreement, and that I am signing it of my own free will. I agree that no oral representations, statements, or inducements apart from this written agreement have been made or implied. I am at least 18 years of age, fully competent, responsible, and legally able to sign this agreement for myself or my dependents.`;
+
 
 interface SignedWaiverModalProps {
   isOpen: boolean;
   onClose: () => void;
   waiver: ISignedWaiver | null;
+  waiverVersion?: IWaiverVersion | null;
 }
 
 export default function SignedWaiverModal({
   isOpen,
   onClose,
   waiver,
+  waiverVersion,
 }: SignedWaiverModalProps) {
   if (!waiver) return null;
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal isOpen={isOpen} onClose={onClose} size="xl" scrollBehavior="inside">
       <ModalOverlay />
       <ModalContent
-        style={{ width: "60vw", height: "40vh", overflow: "auto" }}
+        style={{ width: "60vw", height: "65vh", overflow: "auto" }}
         maxW="100rem"
       >
         <ModalHeader
@@ -43,31 +59,63 @@ export default function SignedWaiverModal({
             width: "100%",
           }}
         >
-          {waiver.signeeName}
+          <Flex direction="column" align="left" p={4}>
+            <Text>{waiver.signeeName}</Text>
+          </Flex>
         </ModalHeader>
         <ModalCloseButton />
-        <hr />
         <ModalBody
           style={{ display: "flex", flexDirection: "column", padding: "0%" }}
           className={styles.parentContainer}
         >
-          <Box className={styles.infoBox}>
-            <Text className={styles.visitorInfoSmallHeader}>
-              Waiver Details
-            </Text>
-            <div className={styles.accountInfo} style={{ display: "flex" }}>
-              <div style={{ width: "100%" }}>
+          {waiverVersion ? (
+            <Box className={styles.infoBox}>
+              <Text className={styles.visitorInfoSmallHeader}>
+                Terms and Conditions
+              </Text>
+              <Textarea
+                value={waiverVersion.body}
+                readOnly
+                height="200px"
+                resize="none"
+                whiteSpace="pre-line"
+                className={styles.scroller}
+                mb={4}
+              />
+              <Text whiteSpace="pre-line" className={styles.fieldInfo}>
+                {waiverVersion.acknowledgement}
+              </Text>
+              <Flex mt={6} justify="space-between" wrap="wrap">
+              <div style={{ width: "45%" }}>
                 <Text className={styles.fieldInfo}>
-                  <Text as="span" className={styles.boldText}>Name</Text><br />
+                  <Text as="span" className={styles.boldText}>Signed by</Text><br />
                   {waiver.signeeName}
                 </Text>
+              </div>
+              <div style={{ width: "45%" }}>
                 <Text className={styles.fieldInfo}>
                   <Text as="span" className={styles.boldText}>Date Signed</Text><br />
                   {new Date(waiver.dateSigned).toLocaleDateString()}
                 </Text>
               </div>
-            </div>
-          </Box>
+              </Flex>
+              {waiver.dependents.length > 0 && (
+                <div style={{ width: "45%" }}>
+                    <Text className={styles.fieldInfo}>
+                        <Text as="span" className={styles.boldText}>Dependents</Text><br />
+                            {waiver.dependents.map((dep, idx) => (
+                            <Text key={idx}>{dep}</Text>
+                            ))}
+                    </Text>
+                </div>
+                )}
+            </Box>
+          ) : (
+            <Box className={styles.infoBox}>
+              <Text className={styles.visitorInfoSmallHeader}>Terms and Conditions</Text>
+              <Text className={styles.fieldInfo}>Waiver not found.</Text>
+            </Box>
+          )}
         </ModalBody>
       </ModalContent>
     </Modal>

--- a/src/app/components/SingleVisitorWaiver.tsx
+++ b/src/app/components/SingleVisitorWaiver.tsx
@@ -6,9 +6,12 @@ import {
   ModalHeader,
   ModalCloseButton,
   ModalBody,
-  Text
+  Text,
+  Flex,
+  Box
 } from "@chakra-ui/react";
 import { ISignedWaiver } from "database/signedWaiverSchema";
+import styles from "../styles/admin/editEvent.module.css";
 
 interface SignedWaiverModalProps {
   isOpen: boolean;
@@ -26,17 +29,45 @@ export default function SignedWaiverModal({
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
-      <ModalContent>
-        <ModalHeader>Signed Waiver</ModalHeader>
+      <ModalContent
+        style={{ width: "60vw", height: "40vh", overflow: "auto" }}
+        maxW="100rem"
+      >
+        <ModalHeader
+          style={{
+            padding: "1% 5%",
+            textAlign: "left",
+            fontSize: "35px",
+            fontWeight: "bold",
+            fontFamily: "Lato",
+            width: "100%",
+          }}
+        >
+          {waiver.signeeName}
+        </ModalHeader>
         <ModalCloseButton />
-        <ModalBody>
-          <Text>
-            <strong>Name:</strong> {waiver.signeeName}
-          </Text>
-          <Text>
-            <strong>Date Signed:</strong>{" "}
-            {new Date(waiver.dateSigned).toLocaleDateString()}
-          </Text>
+        <hr />
+        <ModalBody
+          style={{ display: "flex", flexDirection: "column", padding: "0%" }}
+          className={styles.parentContainer}
+        >
+          <Box className={styles.infoBox}>
+            <Text className={styles.visitorInfoSmallHeader}>
+              Waiver Details
+            </Text>
+            <div className={styles.accountInfo} style={{ display: "flex" }}>
+              <div style={{ width: "100%" }}>
+                <Text className={styles.fieldInfo}>
+                  <Text as="span" className={styles.boldText}>Name</Text><br />
+                  {waiver.signeeName}
+                </Text>
+                <Text className={styles.fieldInfo}>
+                  <Text as="span" className={styles.boldText}>Date Signed</Text><br />
+                  {new Date(waiver.dateSigned).toLocaleDateString()}
+                </Text>
+              </div>
+            </div>
+          </Box>
         </ModalBody>
       </ModalContent>
     </Modal>

--- a/src/app/styles/admin/editEvent.module.css
+++ b/src/app/styles/admin/editEvent.module.css
@@ -239,17 +239,13 @@
 
 .detailsColumn {
   padding: 1.5% 0% 1.5% 3%;
-  text-align: left;
+  text-align: center;
   width: 20%;
   font-size: 15px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   margin-right: 3%;
-}
-
-.detailsColumn:hover {
-  text-decoration-line: underline;
 }
 
 .tableContainer {
@@ -290,8 +286,8 @@
 
 .fieldInfo {
   text-align: left;
-  margin: 3% 5% 3% 5%;
-  font-size: 14px;
+  margin: 20px;
+  font-size: 15px;
   font-family: "Lato";
 
 }
@@ -383,8 +379,12 @@
 }
 
 .link {
-  color: gray;
   text-decoration: underline;
+}
+
+.link:hover {
+  cursor: pointer;
+  color: #337774;
 }
 
 .parentContainer {


### PR DESCRIPTION
## Developer: Kayla Tran

Closes #300 

### Pull Request Summary
For each visitor of an event, showcase whether they have signed a waiver. If they have, link it with a pop-up.

### Modifications
- src/app/admin/events/edit/[eventId]/page.module.css: added css for waiver column to follow other columns styling
- src/app/components/EditEventVisitorInfo.tsx: updated component to have waiver column and to fetch waiver versions and return specific waiver version to waiver pop-up component
- src/app/components/EditEventVisitorInfo.tsx: updated styling of details column to show pointer cusor
- src/app/components/SingleVisitorWaiver.tsx: single waiver component, which shows for each visitors' waiver

### Testing Considerations
- Viewed pop-up and visitor panel locally to check whether things looked and worked as they should
- Tested adding dependents 

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast
<img width="1079" alt="Screenshot 2025-05-12 at 6 11 51 PM" src="https://github.com/user-attachments/assets/72e08fff-b272-4cd5-873c-d32d9a96402a" />
<img width="1082" alt="Screenshot 2025-05-12 at 6 12 17 PM" src="https://github.com/user-attachments/assets/5e3f3ebc-0050-4ebc-b6f9-e5e11be0bd2a" />
