### PR TITLE
fix(333): manage event pages resizes btwn widths of 768 and 1200

### DIFF
--- a/src/app/styles/admin/events.module.css
+++ b/src/app/styles/admin/events.module.css
@@ -106,12 +106,6 @@
 }
 
 @media (max-width: 1200px) {
-  .mainContainer {
-    flex-direction: column;
-    gap: 20px;
-    align-items: center;
-  }
-
   .eventsList {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
@@ -140,6 +134,12 @@
 }
 
 @media (max-width: 768px) {
+  .mainContainer {
+    flex-direction: column;
+    gap: 20px;
+    align-items: center;
+  }
+
   .sidebar {
     width: 100%;
     margin-left: 0;


### PR DESCRIPTION
## Developer: Emily Lai

Closes #333 

### Pull Request Summary

Instead of the mange events page turning into 1 long column on smaller pc screens, create 2 columns (buttons on left, events on right)

### Modifications

The css of browsers under 1200px, but over 768px adjusted

### Testing Considerations

- manage event page should look normal on all screen sizes, and have 2 columns on smaller screen sizes (not including mobile)

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

![image](https://github.com/user-attachments/assets/ece6947a-043d-4f20-8e26-ae6049a8504e)