### PR TITLE
Add Party Members to Events

### DIFF
--- a/src/app/components/EditEventVisitorInfo.tsx
+++ b/src/app/components/EditEventVisitorInfo.tsx
@@ -407,9 +407,10 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
                                 {guest.firstName} {guest.lastName}
                               </td>
                               <td className={styles.emailColumn}>
-                                {guest.email}
+                                Guest - Has not signed
                               </td>
-                              <td className={styles.detailsColumn}></td>
+                              <td className={styles.detailsColumn}>
+                              </td>
                             </tr>
                           ))}
                       </React.Fragment>

--- a/src/app/components/EditEventVisitorInfo.tsx
+++ b/src/app/components/EditEventVisitorInfo.tsx
@@ -30,7 +30,7 @@ const placeholderUser: IUser = {
 const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
   const [loading, setLoading] = useState(true);
   const [visitorData, setVisitorData] = useState<{
-    [key: string]: { parent: IUser; dependents: IUser[] };
+    [key: string]: { parent: IUser; dependents: IUser[]; guests: IUser[]};
   }>({});
   const { eventData, isLoading, isError } = useEventId(eventId);
   const [showAdminActions, setShowAdminActions] = useState(false);
@@ -129,7 +129,7 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
     const fetchVisitorData = async () => {
       if (eventData.eventName !== '') {
         const visitors: {
-          [key: string]: { parent: IUser; dependents: IUser[] };
+          [key: string]: { parent: IUser; dependents: IUser[]; guests: IUser[]};
         } = {};
 
         // Fetch waivers for the event
@@ -144,6 +144,7 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
                 visitors[waiver.signeeId] = {
                   parent: placeholderUser,
                   dependents: [],
+                  guests: [],
                 };
               }
               waiver.dependents.forEach((dependent) => {
@@ -163,7 +164,25 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
                   zipcode: '',
                 });
               });
-            });
+              waiver.guests.forEach((guest) => {
+                visitors[waiver.signeeId].guests.push({
+                  _id: `${guest} Party Member`,
+                  groupId: null,
+                  email: '',
+                  firstName: guest,
+                  lastName: '',
+                  phoneNumber: '',
+                  age: -1,
+                  gender: '',
+                  role: 'guest',
+                  eventsAttended: [],
+                  eventsRegistered: [],
+                  receiveNewsletter: false,
+                  zipcode: '',
+                });
+              });
+            }
+          );
           } else {
             console.error('Error fetching waivers:');
             setLoading(false);
@@ -187,7 +206,7 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
                   const user = await response.json();
 
                   if (!visitors[user._id]) {
-                    visitors[user._id] = { parent: user, dependents: [] };
+                    visitors[user._id] = { parent: user, dependents: [], guests: []};
                   } else {
                     visitors[user._id].parent = user;
                   }
@@ -367,6 +386,28 @@ const EditEventVisitorInfo = ({ eventId }: { eventId: string }) => {
                               </td>
                               <td className={styles.emailColumn}>
                                 {dependent.email}
+                              </td>
+                              <td className={styles.detailsColumn}></td>
+                            </tr>
+                          ))}
+                          {group.guests
+                          .sort((a, b) =>
+                            a.firstName.localeCompare(b.firstName)
+                          )
+                          .map((guest, index) => (
+                            <tr
+                              className={`${styles.visitorRow} ${styles.dependentRow}`}
+                              key={`${parentIndex}-${index}`}
+                            >
+                              <td className={styles.checkBox}></td>
+                              <td
+                                className={styles.nameColumn}
+                                style={{ paddingLeft: '25px' }}
+                              >
+                                {guest.firstName} {guest.lastName}
+                              </td>
+                              <td className={styles.emailColumn}>
+                                {guest.email}
                               </td>
                               <td className={styles.detailsColumn}></td>
                             </tr>

--- a/src/app/events/[eventId]/digitalWaiver/page.tsx
+++ b/src/app/events/[eventId]/digitalWaiver/page.tsx
@@ -118,7 +118,7 @@ export default function Waiver({ params: { eventId } }: IParams) {
   };
 
   const addGuest = () => {
-    if (guests.length >= 6) {
+    if (guests.length >= 5) {
       toast({
         title:
           'You can only add up to 5 guests per registee.',
@@ -410,6 +410,7 @@ export default function Waiver({ params: { eventId } }: IParams) {
             );
             if (waiver) {
               setDependents([...waiver.dependents]);
+              setGuests([...waiver.guests])
               setSignature(waiver.signeeName);
               setExistingWaiver(waiver);
             }

--- a/src/app/events/[eventId]/digitalWaiver/page.tsx
+++ b/src/app/events/[eventId]/digitalWaiver/page.tsx
@@ -39,6 +39,7 @@ export default function Waiver({ params: { eventId } }: IParams) {
   const { mutate } = useEventsAscending();
   const [isScrolledToBottom, setIsScrolledToBottom] = useState(false);
   const [dependents, setDependents] = useState<string[]>([]);
+  const [guests, setGuests] = useState<string[]>([]);
   const [email, setEmail] = useState('');
   const [zipcode, setZipcode] = useState('');
   const [firstName, setFirstName] = useState('');
@@ -116,6 +117,19 @@ export default function Waiver({ params: { eventId } }: IParams) {
     setDependents([...dependents, '']);
   };
 
+  const addGuest = () => {
+    if (guests.length >= 6) {
+      toast({
+        title:
+          'You can only add up to 5 guests per registee.',
+        status: 'error',
+        isClosable: true,
+      });
+      return;
+    }
+    setGuests([...guests, '']);
+  }
+
   const handleDeleteDependent = (indexToDelete: number) => {
     setDependents(dependents.filter((_, index) => index !== indexToDelete));
   };
@@ -124,6 +138,16 @@ export default function Waiver({ params: { eventId } }: IParams) {
     const newDependents = [...dependents];
     newDependents[index] = value;
     setDependents(newDependents);
+  };
+
+  const handleDeleteGuest = (indexToDelete: number) => {
+    setGuests(guests.filter((_, index) => index !== indexToDelete));
+  };
+
+  const handleGuestChange = (index: number, value: string) => {
+    const newGuests = [...guests];
+    newGuests[index] = value;
+    setGuests(newGuests);
   };
 
   function handleSkip() {
@@ -174,8 +198,13 @@ export default function Waiver({ params: { eventId } }: IParams) {
       (dependent) => dependent.trim() !== ''
     );
 
+    const filteredGuests = guests.filter(
+      (guest) => guest.trim() != ''
+    )
+
     const signedWaiver = {
       dependents: filteredDependents,
+      guests: filteredGuests,
       eventId: eventId,
       dateSigned: new Date(),
       waiverVersion: activeWaiver.version,
@@ -189,6 +218,7 @@ export default function Waiver({ params: { eventId } }: IParams) {
           body: JSON.stringify({
             ...existingWaiver,
             dependents: filteredDependents,
+            guests: filteredGuests,
             signeeName: signature,
           }),
         });
@@ -494,6 +524,7 @@ export default function Waiver({ params: { eventId } }: IParams) {
               Add Dependent +
             </button>
 
+
             {/* Dependents Section */}
             <table width="100%">
               <tbody>
@@ -521,6 +552,57 @@ export default function Waiver({ params: { eventId } }: IParams) {
                           />
                           <Button
                             onClick={() => handleDeleteDependent(index)}
+                            size={{ base: 'xs', md: 'sm' }}
+                            colorScheme="red"
+                            variant="outline"
+                            style={{
+                              marginTop: '15px',
+                            }}
+                          >
+                            ×
+                          </Button>
+                        </td>
+                      </tr>
+                    ))
+                  : null}
+              </tbody>
+            </table>
+
+            <button
+              type="button"
+              onClick={addGuest}
+              className={styles.addDependent}
+              style={{ color: '#ECB94A' }}>
+                Add Guest +
+            </button>
+
+            {/* Guests Section */}
+            <table width="100%">
+              <tbody>
+                {guests.length > 0
+                  ? guests.map((name, index) => (
+                      <tr key={index}>
+                        <td
+                          style={{
+                            display: 'flex',
+                            gap: '10px',
+                            alignItems: 'center',
+                          }}
+                        >
+                          <input
+                            className={styles.dependentTable}
+                            type="text"
+                            value={name}
+                            onChange={(event) =>
+                              handleGuestChange(index, event.target.value)
+                            }
+                            style={{
+                              flex: 1,
+                            }}
+                            placeholder="Guest Full Name"
+                          />
+                          <Button
+                            onClick={() => handleDeleteGuest(index)}
                             size={{ base: 'xs', md: 'sm' }}
                             colorScheme="red"
                             variant="outline"

--- a/src/app/events/[eventId]/digitalWaiver/page.tsx
+++ b/src/app/events/[eventId]/digitalWaiver/page.tsx
@@ -573,7 +573,7 @@ export default function Waiver({ params: { eventId } }: IParams) {
               onClick={addGuest}
               className={styles.addDependent}
               style={{ color: '#ECB94A' }}>
-                Add Guest +
+                Add Party Member +
             </button>
 
             {/* Guests Section */}
@@ -599,7 +599,7 @@ export default function Waiver({ params: { eventId } }: IParams) {
                             style={{
                               flex: 1,
                             }}
-                            placeholder="Guest Full Name"
+                            placeholder="Party Member Full Name"
                           />
                           <Button
                             onClick={() => handleDeleteGuest(index)}

--- a/src/database/signedWaiverSchema.ts
+++ b/src/database/signedWaiverSchema.ts
@@ -6,6 +6,7 @@ export type ISignedWaiver = {
     signeeId: string;
     signeeName: string;
     dependents: string[];
+    guests: string[];
     eventId: string;
     dateSigned: Date;
     waiverVersion: number;
@@ -21,6 +22,11 @@ const signedWaiverSchema = new Schema({
         required: true,
     },
     dependents: {
+        type: [String],
+        default: [],
+        required: false,
+    },
+    guests: {
         type: [String],
         default: [],
         required: false,


### PR DESCRIPTION
## Developer: Brady Welsh

Closes #342 

### Pull Request Summary

- Party members/guests are now part of waiver info, who count as attendees that must sign waivers when they get on site of the event
- These are added on the waiver page right below the dependents
- They show up on the edit event page in the visitor event box 

### Modifications

- db/signedWaiverSchema - schema changed to add guests as an attribute
- events/[eventId]/digitalWaiver/page.tsx - added an "Add Party Members" button which functions the same as the Add Dependents one. When the user signs, these party members/guests are properly sent to the DB.
- comopnents/editEventVisitoInfo.tsx - the party members are mapped and displayed in the box - in their email column is a note that they are a guest and have not signed the waiver yet 

### Testing Considerations

- I've tested that everything works correctly for the changes listed above
- However, one thing to consider/fix: These party members should count towards the headcount of the event, however, I wasn't 100% sure. Also, with how the current headcount works, major changes would be needed to it to support this (since currently the headcount looks at the event data, whereas it would have to be restructured to look at waiver data), so I think it would be better as a separate issue.

### Screenshots/Screencast

<img width="1292" alt="image" src="https://github.com/user-attachments/assets/5612aabc-5268-422d-a78b-f45d922b30e4" />

<img width="1292" alt="image" src="https://github.com/user-attachments/assets/f117f61a-4ee2-4e47-84af-d9b0633a4b9d" />

<img width="524" alt="image" src="https://github.com/user-attachments/assets/59a5ea31-8a8a-4361-a719-a67b241fa800" />

