### PR TITLE
Waiver Signed now appears on waiver page

### DIFF
--- a/src/app/events/[eventId]/digitalWaiver/page.tsx
+++ b/src/app/events/[eventId]/digitalWaiver/page.tsx
@@ -53,6 +53,7 @@ export default function Waiver({ params: { eventId } }: IParams) {
   const [eventData, setEventData] = useState<IEvent | null>(null);
   const [emailChecked, setEmailChecked] = useState(false);
   const [validEmail, setValidEmail] = useState(false);
+  const [hasSigned, setHasSigned] = useState(false);
   const [activeWaiver, setActiveWaiver] = useState<any>(null);
   const [existingWaiver, setExistingWaiver] = useState<ISignedWaiver | null>(
     null
@@ -60,6 +61,7 @@ export default function Waiver({ params: { eventId } }: IParams) {
 
   // Fetch active waiver
   useEffect(() => {
+
     const fetchActiveWaiver = async () => {
       try {
         const response = await fetch('/api/waiver-versions');
@@ -88,7 +90,36 @@ export default function Waiver({ params: { eventId } }: IParams) {
       }
     };
 
-    fetchActiveWaiver();
+    const fetchSignedWaiver = async () => {
+      try {
+        const response = await fetch(`/api/waiver/${eventId}`, {
+            method: 'GET',
+            headers: { 'Content-Type': 'application/json' },
+        });
+        const data = await response.json();
+        const existing = data.signedWaivers.find((w: any) => w.signeeId === userData?._id)
+
+        if (existing) {
+          setExistingWaiver(existing);
+        }
+
+      } catch (error) {
+        console.error('Error fetching signed waiver:', error);
+        toast({
+          title: 'Error loading waiver',
+          description: 'Please try again later',
+          status: 'error',
+          duration: 5000,
+          isClosable: true,
+        });
+      }
+    }
+    
+    if (hasSigned) {
+      fetchSignedWaiver();
+    } else {
+      fetchActiveWaiver();
+    }
   }, []);
 
   // Update the waiver text to use active waiver content

--- a/src/app/events/[eventId]/digitalWaiver/page.tsx
+++ b/src/app/events/[eventId]/digitalWaiver/page.tsx
@@ -92,15 +92,21 @@ export default function Waiver({ params: { eventId } }: IParams) {
 
     const fetchSignedWaiver = async () => {
       try {
-        const response = await fetch(`/api/waiver/${eventId}`, {
+        const signedWaiverResponse = await fetch(`/api/waiver/${eventId}`, {
             method: 'GET',
             headers: { 'Content-Type': 'application/json' },
         });
-        const data = await response.json();
-        const existing = data.signedWaivers.find((w: any) => w.signeeId === userData?._id)
+        const signedWaiverData = await signedWaiverResponse.json();
+        const waiverVersionsResponse = await fetch('/api/waiver-versions');
+        const waiverVersionsData = await waiverVersionsResponse.json();
 
-        if (existing) {
-          setExistingWaiver(existing);
+        const existing = signedWaiverData.find((w: any) => w.signeeId === userData?._id);
+        const existingSignedWaiver = waiverVersionsData.waiverVersions.find((w: any) => w.version === existing.waiverVersion);
+
+
+
+        if (existingSignedWaiver) {
+          setActiveWaiver(existingSignedWaiver);
         }
 
       } catch (error) {
@@ -115,12 +121,12 @@ export default function Waiver({ params: { eventId } }: IParams) {
       }
     }
     
-    if (hasSigned) {
+    if (userData && eventData?.registeredIds.includes(userData._id)) {
       fetchSignedWaiver();
     } else {
       fetchActiveWaiver();
     }
-  }, []);
+  }, [eventData, userData]);
 
   // Update the waiver text to use active waiver content
   const waiverText = activeWaiver?.body || 'Loading waiver...';


### PR DESCRIPTION
## Developer: Brady Welsh

Closes #348 

### Pull Request Summary

- Previously, the waiver on the event/digitalWaiver page, the active waiver would display, not necessarily the one the user actually signed. This issue has been fixed
- The useEffect now functions differently depending on if the user has already signed the waiver for the event:
- If they haven't signed the waiver, the active waiver is displayed.
- If they have signed the waiver, a new fetch call is made to get the waiver version that the user signed, and that waiver version is displayed.

### Modifications

- events/[eventId]/page.tsx: the changes listed above to ensure the issue works as intended. All changes were made inside the same useEffect I believe.

### Testing Considerations

- I tested by changing the activeWaiver to a test one and compared it to what showed on the page for an event I signed a different version of (Also shown in screenshots)
- I changed the waiver back after this test

### Screenshots/Screencast

<img width="1466" alt="image" src="https://github.com/user-attachments/assets/d9cc1231-2660-49ef-8d21-387dfea28e49" />

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/0b49ff1b-f70b-482a-b2cc-11ecc33bc23e" />

