### PR TITLE
355 sign out button isn't shy anymore

### DIFF
--- a/src/app/styles/navbar/navbar.module.css
+++ b/src/app/styles/navbar/navbar.module.css
@@ -99,7 +99,7 @@
   margin-right: 10px;
 }
 
-@media (max-width: 1300px) {
+@media (max-width: 1350px) {
   .nav_elements ul a {
     font-size: 14px;
   }
@@ -118,7 +118,7 @@
   }
 }
 
-@media (max-width: 1180px) {
+@media (max-width: 1230px) {
   .nav_elements ul li {
     font-size: 14px;
     margin-right: 10px;
@@ -129,7 +129,7 @@
   }
 }
 
-@media (max-width: 1100px) {
+@media (max-width: 1150px) {
   .nav_elements ul li {
     margin-right: 10px;
     margin-left: 10px;
@@ -140,7 +140,7 @@
   }
 }
 
-@media (max-width: 1050px) {
+@media (max-width: 1100px) {
   .menu_icon {
     display: block;
     cursor: pointer;


### PR DESCRIPTION
## Developer: Vinpatrik Magdangal

Closes #355 

### Pull Request Summary

The super admin navbar had too many buttons on it and at certain window sizes the sign out button gets shy and tries to hide out of the page. I increased the max width of when the navbar adjusts its size and forced the sign out to be part of the party.

### Modifications

src/app/styles/navbar/navbar.module.css
- added 50px to max width in the @ media properties

### Testing Considerations

Make sure the navbar doesn't shrink badly and everything still appears.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

<img width="199" alt="image" src="https://github.com/user-attachments/assets/9e522eea-d68f-481e-9e96-bb9d1265da89" />
